### PR TITLE
feat: 内部 .md リンクのファイル遷移対応

### DIFF
--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -29,13 +29,20 @@ const findFirstFile = (files: FileNode[]): string | null => {
 const renderContent = (
   selectedPath: string | null,
   viewMode: ViewMode,
-  content: string
+  content: string,
+  onNavigate: (path: string) => void
 ) => {
   if (!selectedPath) {
     return <p className="text-muted-foreground">ファイルを選択してください</p>;
   }
   if (viewMode === "preview") {
-    return <Preview content={content} selectedPath={selectedPath} />;
+    return (
+      <Preview
+        content={content}
+        selectedPath={selectedPath}
+        onNavigate={onNavigate}
+      />
+    );
   }
   return <Source content={content} />;
 };
@@ -198,7 +205,7 @@ export const App = () => {
 
         {/* コンテンツ */}
         <div className="flex-1 overflow-y-auto px-8 py-8">
-          {renderContent(selectedPath, viewMode, content)}
+          {renderContent(selectedPath, viewMode, content, setSelectedPath)}
         </div>
       </main>
       <QuickOpen

--- a/src/client/components/preview.tsx
+++ b/src/client/components/preview.tsx
@@ -1,6 +1,6 @@
 import { Check, Clipboard } from "lucide-react";
 import { Highlight, themes } from "prism-react-renderer";
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef, MouseEvent } from "react";
 import { useCallback, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -10,6 +10,7 @@ import { useTheme } from "@/hooks/use-theme.js";
 interface PreviewProps {
   content: string;
   selectedPath: string | null;
+  onNavigate: (path: string) => void;
 }
 
 const isExternalUrl = (src: string): boolean =>
@@ -47,14 +48,75 @@ const CopyButton = ({ text }: { text: string }) => {
   );
 };
 
-export const Preview = ({ content, selectedPath }: PreviewProps) => {
+const resolvePath = (from: string, relative: string): string => {
+  const dir = from.includes("/") ? from.slice(0, from.lastIndexOf("/")) : "";
+  const parts = dir ? dir.split("/") : [];
+
+  for (const segment of relative.split("/")) {
+    if (segment === "..") {
+      parts.pop();
+    } else if (segment !== "." && segment !== "") {
+      parts.push(segment);
+    }
+  }
+
+  return parts.join("/");
+};
+
+const MdLink = ({
+  href,
+  children,
+  selectedPath,
+  onNavigate,
+  ...props
+}: ComponentPropsWithoutRef<"a"> & {
+  selectedPath: string | null;
+  onNavigate: (path: string) => void;
+}) => {
+  const handleClick = useCallback(
+    (e: MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+      if (selectedPath && href) {
+        onNavigate(resolvePath(selectedPath, href));
+      }
+    },
+    [selectedPath, href, onNavigate]
+  );
+
+  if (href?.endsWith(".md") && selectedPath) {
+    return (
+      <a {...props} href={href} onClick={handleClick}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+      {children}
+    </a>
+  );
+};
+
+export const Preview = ({
+  content,
+  selectedPath,
+  onNavigate,
+}: PreviewProps) => {
   const { theme } = useTheme();
+
+  const renderLink = useCallback(
+    (props: ComponentPropsWithoutRef<"a">) => (
+      <MdLink {...props} selectedPath={selectedPath} onNavigate={onNavigate} />
+    ),
+    [selectedPath, onNavigate]
+  );
 
   return (
     <div className="prose dark:prose-invert max-w-[960px] mx-auto prose-pre:bg-[#f6f8fa] dark:prose-pre:bg-[#161b22] prose-pre:p-4 prose-code:before:content-none prose-code:after:content-none prose-h1:border-b prose-h1:border-border prose-h1:pb-2 prose-h2:border-b prose-h2:border-border prose-h2:pb-2">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
+          a: renderLink,
           code({
             className,
             children,


### PR DESCRIPTION
## Summary
- `preview.tsx` に `a` カスタムコンポーネントを追加し、`.md` リンクをインターセプト
- `.md` リンククリック時に `onNavigate` でファイル遷移（ページ遷移なし）
- 外部リンクは `target="_blank" rel="noopener noreferrer"` で新タブで開く
- 相対パスの正規化（`../` 等）に対応

Closes #8

## Test plan
- [ ] `.md` リンクをクリックしてファイルが切り替わるか確認
- [ ] 相対パス（`../other.md`）のリンクが正しく解決されるか確認
- [ ] 外部リンクが新タブで開くか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)