### PR TITLE
feat: ローカル画像の表示対応

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": ["src/server/cli.ts"],
   "project": ["src/**/*.{ts,tsx}"],
   "ignore": ["src/client/components/ui/**", "src/client/lib/**"],
-  "ignoreBinaries": ["nr"],
+  "ignoreBinaries": [],
   "ignoreDependencies": [
     "@base-ui/react",
     "class-variance-authority",

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -35,7 +35,7 @@ const renderContent = (
     return <p className="text-muted-foreground">ファイルを選択してください</p>;
   }
   if (viewMode === "preview") {
-    return <Preview content={content} />;
+    return <Preview content={content} selectedPath={selectedPath} />;
   }
   return <Source content={content} />;
 };

--- a/src/client/components/preview.tsx
+++ b/src/client/components/preview.tsx
@@ -9,7 +9,22 @@ import { useTheme } from "@/hooks/use-theme.js";
 
 interface PreviewProps {
   content: string;
+  selectedPath: string | null;
 }
+
+const isExternalUrl = (src: string): boolean =>
+  src.startsWith("http://") ||
+  src.startsWith("https://") ||
+  src.startsWith("data:");
+
+const resolveImageSrc = (src: string, selectedPath: string | null): string => {
+  if (isExternalUrl(src)) {
+    return src;
+  }
+  const dir = selectedPath ? selectedPath.replace(/[^/]+$/, "") : "";
+  const imagePath = dir + src.replace(/^\.\//, "");
+  return `/api/image?path=${encodeURIComponent(imagePath)}`;
+};
 
 const CopyButton = ({ text }: { text: string }) => {
   const [copied, setCopied] = useState(false);
@@ -32,7 +47,7 @@ const CopyButton = ({ text }: { text: string }) => {
   );
 };
 
-export const Preview = ({ content }: PreviewProps) => {
+export const Preview = ({ content, selectedPath }: PreviewProps) => {
   const { theme } = useTheme();
 
   return (
@@ -89,6 +104,10 @@ export const Preview = ({ content }: PreviewProps) => {
                 )}
               </Highlight>
             );
+          },
+          img({ src, alt, ...props }: ComponentPropsWithoutRef<"img">) {
+            const resolvedSrc = src ? resolveImageSrc(src, selectedPath) : "";
+            return <img src={resolvedSrc} alt={alt ?? ""} {...props} />;
           },
           pre({ children, ...props }: ComponentPropsWithoutRef<"pre">) {
             const codeEl = Array.isArray(children) ? children[0] : children;

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,13 +1,34 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 
 import { Hono } from "hono";
 
 import { scanMarkdownFiles } from "./files.js";
-import { SecurityError, validatePath } from "./security.js";
+import { SecurityError, validateImagePath, validatePath } from "./security.js";
+
+const IMAGE_CONTENT_TYPES: Record<string, string> = {
+  ".gif": "image/gif",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+};
 
 const readFile = async (filePath: string, baseDir: string): Promise<string> => {
   const resolvedPath = validatePath(filePath, baseDir);
   return await fs.readFile(resolvedPath, "utf8");
+};
+
+const readImage = async (
+  filePath: string,
+  baseDir: string
+): Promise<{ data: Buffer; contentType: string }> => {
+  const resolvedPath = validateImagePath(filePath, baseDir);
+  const ext = path.extname(resolvedPath).toLowerCase();
+  const contentType = IMAGE_CONTENT_TYPES[ext] ?? "application/octet-stream";
+  const data = await fs.readFile(resolvedPath);
+  return { contentType, data };
 };
 
 export const createApiRouter = (baseDir: string): Hono => {
@@ -36,6 +57,23 @@ export const createApiRouter = (baseDir: string): Hono => {
         return c.json({ error: error.message }, 400);
       }
       return c.json({ error: "File not found" }, 404);
+    }
+  });
+
+  api.get("/api/image", async (c) => {
+    const filePath = c.req.query("path");
+    if (!filePath) {
+      return c.json({ error: "path query parameter is required" }, 400);
+    }
+
+    try {
+      const { data, contentType } = await readImage(filePath, baseDir);
+      return c.body(data, 200, { "Content-Type": contentType });
+    } catch (error) {
+      if (error instanceof SecurityError) {
+        return c.json({ error: error.message }, 400);
+      }
+      return c.json({ error: "Image not found" }, 404);
     }
   });
 

--- a/src/server/security.ts
+++ b/src/server/security.ts
@@ -11,9 +11,25 @@ export class SecurityError extends Error {
 const isWithinBaseDir = (targetPath: string, baseDir: string): boolean =>
   targetPath.startsWith(baseDir + path.sep) || targetPath === baseDir;
 
+const ALLOWED_IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".svg",
+  ".webp",
+]);
+
 const validateExtension = (filePath: string): void => {
   if (!filePath.endsWith(".md")) {
     throw new SecurityError(`Only .md files are allowed: ${filePath}`);
+  }
+};
+
+const validateImageExtension = (filePath: string): void => {
+  const ext = path.extname(filePath).toLowerCase();
+  if (!ALLOWED_IMAGE_EXTENSIONS.has(ext)) {
+    throw new SecurityError(`Unsupported image format: ${filePath}`);
   }
 };
 
@@ -45,6 +61,22 @@ export const validatePath = (filePath: string, baseDir: string): string => {
   }
 
   validateExtension(decoded);
+
+  return resolveRealPath(resolved, baseDir, filePath);
+};
+
+export const validateImagePath = (
+  filePath: string,
+  baseDir: string
+): string => {
+  const decoded = decodeURIComponent(filePath);
+  const resolved = path.resolve(baseDir, decoded);
+
+  if (!isWithinBaseDir(resolved, baseDir)) {
+    throw new SecurityError(`Path traversal detected: ${filePath}`);
+  }
+
+  validateImageExtension(decoded);
 
   return resolveRealPath(resolved, baseDir, filePath);
 };


### PR DESCRIPTION
Markdown 内の相対パス画像を API 経由で配信する機能を追加。
パストラバーサル対策付きの validateImagePath で安全に画像を提供し、
react-markdown のカスタム img コンポーネントで相対パスを自動変換。

対応形式: png, jpg, jpeg, gif, svg, webp

関連: #7