### PR TITLE
fix: publish ワークフローを npm Trusted Publishing に対応

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -36,4 +36,4 @@ jobs:
         run: pnpm build
 
       - name: Publish
-        run: pnpm publish --no-git-checks --provenance --access public
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- `pnpm publish` → `npm publish` に変更（pnpm は OIDC Trusted Publishing 未対応）
- Node.js 22 → 24 に更新（Trusted Publishing の要件: npm >= 11.5.1 / Node >= 24）

## Test plan
- [ ] CI が通ること
- [ ] マージ後、v0.2.0 リリースの publish ワークフローを re-run して npm 公開を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)