### PR TITLE
fix: npm を最新版に更新して OIDC Trusted Publishing に対応

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,9 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - name: Lint


### PR DESCRIPTION
## Summary
- Publish ステップ前に `npm install -g npm@latest` を追加
- GitHub Actions ランナーのデフォルト npm が OIDC 未対応のため 404 エラーが発生していた

## Test plan
- [ ] CI が通ること
- [ ] マージ後、v0.2.0 リリースを再作成して npm 公開を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)