### PR TITLE
feat: ファイルツリーの横幅をドラッグでリサイズ可能にする

### DIFF
--- a/e2e/resize-sidebar.test.ts
+++ b/e2e/resize-sidebar.test.ts
@@ -1,0 +1,70 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+const getBox = async (locator: ReturnType<Page["locator"]>) => {
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error("Element not found");
+  }
+  return box;
+};
+
+const dragHandle = async (
+  page: Page,
+  handle: ReturnType<Page["getByRole"]>,
+  targetX: number
+) => {
+  const box = await getBox(handle);
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(targetX, box.y + box.height / 2);
+  await page.mouse.up();
+};
+
+const getSidebarWidth = async (page: Page) => {
+  const box = await getBox(page.locator("aside"));
+  return box.width;
+};
+
+test("サイドバーの幅をドラッグで変更できる", async ({ page }) => {
+  await page.goto("/");
+  const handle = page.getByRole("separator");
+
+  const initialWidth = await getSidebarWidth(page);
+  expect(initialWidth).toBe(256);
+
+  const handleBox = await getBox(handle);
+  await dragHandle(page, handle, handleBox.x + 100);
+
+  const newWidth = await getSidebarWidth(page);
+  expect(newWidth).toBeGreaterThan(initialWidth);
+});
+
+test("サイドバーの幅が最小幅・最大幅でクランプされる", async ({ page }) => {
+  await page.goto("/");
+  const handle = page.getByRole("separator");
+
+  // 極端に左 → 最小幅（160px）
+  await dragHandle(page, handle, 0);
+  expect(await getSidebarWidth(page)).toBe(160);
+
+  // 極端に右 → 最大幅（480px）
+  await dragHandle(page, handle, 1000);
+  expect(await getSidebarWidth(page)).toBe(480);
+});
+
+test("リサイズハンドルをダブルクリックでデフォルト幅にリセットされる", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const handle = page.getByRole("separator");
+
+  // ドラッグで幅を変更
+  const handleBox = await getBox(handle);
+  await dragHandle(page, handle, handleBox.x + 100);
+
+  // ダブルクリックでリセット（トランジション完了を待つ）
+  await handle.dblclick();
+  await page.waitForTimeout(300);
+  expect(await getSidebarWidth(page)).toBe(256);
+});

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -2,7 +2,7 @@ import type { FileNode } from "@shared/types.js";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import type React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { fetchFile, fetchFiles } from "./api.js";
 import { FileTree } from "./components/file-tree.js";
@@ -10,6 +10,8 @@ import { Preview } from "./components/preview.js";
 import { QuickOpen } from "./components/quick-open.js";
 import { Source } from "./components/source.js";
 import { ThemeToggle } from "./components/theme-toggle.js";
+import { useResizable } from "./hooks/use-resizable.js";
+import { cn } from "./lib/utils.js";
 
 type ViewMode = "preview" | "source";
 
@@ -89,7 +91,6 @@ const useLoadContent = (
 };
 
 const useAppHandlers = (
-  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>,
   setViewMode: React.Dispatch<React.SetStateAction<ViewMode>>,
   setQuickOpenVisible: React.Dispatch<React.SetStateAction<boolean>>
 ) => ({
@@ -99,10 +100,6 @@ const useAppHandlers = (
   ),
   handleSetPreview: useCallback(() => setViewMode("preview"), [setViewMode]),
   handleSetSource: useCallback(() => setViewMode("source"), [setViewMode]),
-  handleToggleSidebar: useCallback(
-    () => setSidebarOpen((v) => !v),
-    [setSidebarOpen]
-  ),
 });
 
 const useHotkeys = (
@@ -111,6 +108,26 @@ const useHotkeys = (
 ) => {
   useHotkey("Mod+P", () => setQuickOpenVisible(true));
   useHotkey("Mod+B", () => setSidebarOpen((v) => !v));
+};
+
+const useSidebar = (
+  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+  const sidebarRef = useRef<HTMLElement>(null);
+  const { isDragging, onDoubleClick, onMouseDown, width } =
+    useResizable(sidebarRef);
+
+  return {
+    handleToggleSidebar: useCallback(
+      () => setSidebarOpen((v) => !v),
+      [setSidebarOpen]
+    ),
+    isDragging,
+    onDoubleClick,
+    onMouseDown,
+    sidebarRef,
+    sidebarWidth: width,
+  };
 };
 
 const useAppState = () => {
@@ -126,7 +143,8 @@ const useAppState = () => {
   useLoadContent(selectedPath, setContent);
 
   return {
-    ...useAppHandlers(setSidebarOpen, setViewMode, setQuickOpenVisible),
+    ...useAppHandlers(setViewMode, setQuickOpenVisible),
+    ...useSidebar(setSidebarOpen),
     content,
     files,
     quickOpenVisible,
@@ -145,25 +163,55 @@ export const App = () => {
     handleSetPreview,
     handleSetSource,
     handleToggleSidebar,
+    isDragging,
+    onDoubleClick,
+    onMouseDown,
     quickOpenVisible,
     selectedPath,
     setSelectedPath,
     sidebarOpen,
+    sidebarRef,
+    sidebarWidth,
     viewMode,
   } = useAppState();
 
   return (
-    <div className="flex h-screen bg-background text-foreground">
+    <div
+      className={cn(
+        "flex h-screen bg-background text-foreground",
+        isDragging && "select-none cursor-col-resize"
+      )}
+    >
       {/* サイドバー */}
       {sidebarOpen && (
-        <aside className="w-64 border-r border-border overflow-y-auto p-4 bg-secondary">
-          <h1 className="text-lg font-bold mb-4">specv</h1>
-          <FileTree
-            files={files}
-            selectedPath={selectedPath}
-            onSelect={setSelectedPath}
+        <>
+          <aside
+            ref={sidebarRef}
+            className={cn(
+              "shrink-0 border-r border-border overflow-y-auto p-4 bg-secondary transition-[width] duration-200",
+              isDragging && "!transition-none"
+            )}
+            style={{ width: sidebarWidth }}
+          >
+            <h1 className="text-lg font-bold mb-4">specv</h1>
+            <FileTree
+              files={files}
+              selectedPath={selectedPath}
+              onSelect={setSelectedPath}
+            />
+          </aside>
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            className={cn(
+              "relative w-1 shrink-0 cursor-col-resize hover:bg-ring transition-colors",
+              "before:absolute before:inset-y-0 before:-left-1 before:-right-1",
+              isDragging && "bg-ring"
+            )}
+            onDoubleClick={onDoubleClick}
+            onMouseDown={onMouseDown}
           />
-        </aside>
+        </>
       )}
 
       {/* メインエリア */}

--- a/src/client/hooks/use-resizable.ts
+++ b/src/client/hooks/use-resizable.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const DEFAULT_WIDTH = 256;
+const MAX_WIDTH = 480;
+const MIN_WIDTH = 160;
+
+export const useResizable = (
+  sidebarRef: React.RefObject<HTMLElement | null>
+) => {
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
+  const [isDragging, setIsDragging] = useState(false);
+  const rafRef = useRef<number>(0);
+  const offsetLeftRef = useRef(0);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.detail > 1) {
+        return;
+      }
+      e.preventDefault();
+      offsetLeftRef.current =
+        sidebarRef.current?.getBoundingClientRect().left ?? 0;
+      setIsDragging(true);
+    },
+    [sidebarRef]
+  );
+
+  const onDoubleClick = useCallback(() => {
+    setWidth(DEFAULT_WIDTH);
+  }, []);
+
+  useEffect(() => {
+    if (!isDragging) {
+      return;
+    }
+
+    const handleMouseMove = (e: MouseEvent) => {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        const clamped = Math.min(
+          MAX_WIDTH,
+          Math.max(MIN_WIDTH, e.clientX - offsetLeftRef.current)
+        );
+        setWidth((prev) => (prev === clamped ? prev : clamped));
+      });
+    };
+
+    const handleMouseUp = () => {
+      cancelAnimationFrame(rafRef.current);
+      setIsDragging(false);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging, sidebarRef]);
+
+  return { isDragging, onDoubleClick, onMouseDown, width };
+};


### PR DESCRIPTION
## 概要
サイドバーの固定幅（256px）を廃止し、ドラッグでリサイズ可能にした。長いファイル名が truncate で切れる問題を改善する。
Closes #13

## 設計判断
- `useResizable` フックで RAF ベースのドラッグ処理を実装（CSS resize や ResizeObserver と比較して、min/max クランプとダブルクリックリセットの制御が容易）
- `useSidebar` フックにサイドバー関連ロジックを集約（max-statements lint ルール対応 + 関心の分離）
- 幅の永続化（localStorage）は不要と判断。毎回デフォルト 256px で開始するシンプルな設計
- `e.detail > 1` ガードでダブルクリック時のドラッグ誤発火を防止

## 変更内容
- `useResizable` フック: ドラッグ操作で幅を 160px〜480px の範囲で変更
- `useSidebar` フック: リサイズ + トグルのロジックを集約
- リサイズハンドル (`role="separator"`): ホバー/ドラッグ時のビジュアルフィードバック
- ダブルクリックでデフォルト幅（256px）にリセット（トランジション付き）
- ドラッグ中: テキスト選択防止 + トランジション無効化
- E2E テスト 3 件追加

## テスト計画
- [x] `nr test` — ユニットテスト 57 件通過
- [x] `nr test:e2e` — E2E テスト 13 件全通過（新規 3 件含む）
- [x] `nr typecheck` — 型エラーなし
- [x] `nr check` — lint エラーなし