### PR TITLE
feat: ホットリロード機能を追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,7 +8,7 @@
 - **Backend**: Hono + @hono/node-server
 - **Test**: Vitest (unit) + Playwright (E2E)
 - **Lint**: Ultracite (Oxlint + Oxfmt) + Knip
-- **Git hooks**: lefthook (pre-commit: ultracite + knip)
+- **Git hooks**: lefthook (pre-commit: ultracite + knip + typecheck)
 
 ## Commands
 
@@ -42,9 +42,10 @@ src/
 │   └── app.tsx       # Main App component
 ├── server/
 │   ├── cli.ts        # CLI entry (Hono + Node server)
-│   ├── api.ts        # API routes (/api/files, /api/file, /api/image)
+│   ├── api.ts        # API routes (/api/files, /api/file, /api/image, /api/watch)
 │   ├── files.ts      # scanMarkdownFiles (recursive .md scanner)
-│   └── security.ts   # Path traversal protection
+│   ├── security.ts   # Path traversal protection
+│   └── watcher.ts    # File watcher (hot reload)
 ├── shared/
 │   └── types.ts      # Shared types (FileNode)
 tests/                # Unit tests (Vitest)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,6 +58,10 @@ fixtures/             # Manual testing markdown files
 - `@server/*` → `src/server/*`
 - `@shared/*` → `src/shared/*`
 
+## Development Style
+
+- TDD（テスト駆動開発）で実装する: テストを先に書き、Red → Green → Refactor のサイクルで進める
+
 ## Gotchas
 
 - `preview.tsx` は remark/rehype プラグインを使用: remarkGfm, remarkMath, remarkAlert, rehypeKatex, rehypeSlug, rehypeAutolinkHeadings

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -11,22 +11,12 @@ import { QuickOpen } from "./components/quick-open";
 import { Source } from "./components/source";
 import { ThemeToggle } from "./components/theme-toggle";
 import { useResizable } from "./hooks/use-resizable";
+import { useScrollRestore } from "./hooks/use-scroll-restore";
+import { useWatch } from "./hooks/use-watch";
 import { cn } from "./lib/utils";
+import { findFirstFile } from "./utils/auto-expand";
 
 type ViewMode = "preview" | "source";
-
-const findFirstFile = (files: FileNode[]): string | null => {
-  for (const f of files) {
-    if (!f.children) {
-      return f.path;
-    }
-    const child = findFirstFile(f.children);
-    if (child) {
-      return child;
-    }
-  }
-  return null;
-};
 
 const renderContent = (
   selectedPath: string | null,
@@ -137,26 +127,32 @@ const useLifecycle = () => {
   }, []);
 };
 
-const useAppState = () => {
+const useContentState = () => {
   const [files, setFiles] = useState<FileNode[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [content, setContent] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useLoadFiles(setFiles, setSelectedPath);
+  useLoadContent(selectedPath, setContent);
+  useWatch(selectedPath, setContent, setFiles, setSelectedPath);
+  useScrollRestore(scrollRef, selectedPath);
+
+  return { content, files, scrollRef, selectedPath, setSelectedPath };
+};
+
+const useAppState = () => {
   const [viewMode, setViewMode] = useState<ViewMode>("preview");
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [quickOpenVisible, setQuickOpenVisible] = useState(false);
 
   useHotkeys(setQuickOpenVisible, setSidebarOpen);
-  useLoadFiles(setFiles, setSelectedPath);
-  useLoadContent(selectedPath, setContent);
 
   return {
     ...useAppHandlers(setViewMode, setQuickOpenVisible),
+    ...useContentState(),
     ...useSidebar(setSidebarOpen),
-    content,
-    files,
     quickOpenVisible,
-    selectedPath,
-    setSelectedPath,
     sidebarOpen,
     viewMode,
   };
@@ -176,6 +172,7 @@ export const App = () => {
     onDoubleClick,
     onMouseDown,
     quickOpenVisible,
+    scrollRef,
     selectedPath,
     setSelectedPath,
     sidebarOpen,
@@ -261,7 +258,7 @@ export const App = () => {
         </header>
 
         {/* コンテンツ */}
-        <div className="flex-1 overflow-y-auto px-8 py-8">
+        <div ref={scrollRef} className="flex-1 overflow-y-auto px-8 py-8">
           {renderContent(selectedPath, viewMode, content, setSelectedPath)}
         </div>
       </main>

--- a/src/client/hooks/use-scroll-restore.ts
+++ b/src/client/hooks/use-scroll-restore.ts
@@ -1,0 +1,16 @@
+import type React from "react";
+import { useEffect, useRef } from "react";
+
+export const useScrollRestore = (
+  scrollRef: React.RefObject<HTMLDivElement | null>,
+  selectedPath: string | null
+): void => {
+  const prevPathRef = useRef(selectedPath);
+
+  useEffect(() => {
+    if (prevPathRef.current !== selectedPath && scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+    prevPathRef.current = selectedPath;
+  }, [selectedPath, scrollRef]);
+};

--- a/src/client/hooks/use-watch.ts
+++ b/src/client/hooks/use-watch.ts
@@ -1,0 +1,44 @@
+import type { FileNode } from "@shared/types";
+import { useEffect, useRef } from "react";
+
+import { fetchFile } from "@/api";
+import { handleFileChanged, handleTreeChanged } from "@/utils/watch-handler";
+
+export const useWatch = (
+  selectedPath: string | null,
+  setContent: (content: string) => void,
+  setFiles: (files: FileNode[]) => void,
+  setSelectedPath: (path: string | null) => void
+): void => {
+  const selectedPathRef = useRef(selectedPath);
+  selectedPathRef.current = selectedPath;
+
+  useEffect(() => {
+    const es = new EventSource("/api/watch");
+
+    const actions = {
+      fetchAndSetContent: async (path: string) => {
+        try {
+          const content = await fetchFile(path);
+          setContent(content);
+        } catch (error) {
+          console.error(error);
+        }
+      },
+      setFiles,
+      setSelectedPath,
+    };
+
+    es.addEventListener("file-changed", (e) => {
+      const { path } = JSON.parse(e.data);
+      handleFileChanged(path, selectedPathRef.current, actions);
+    });
+
+    es.addEventListener("tree-changed", (e) => {
+      const { files } = JSON.parse(e.data);
+      handleTreeChanged(files, selectedPathRef.current, actions);
+    });
+
+    return () => es.close();
+  }, [setContent, setFiles, setSelectedPath]);
+};

--- a/src/client/lib/markdown-plugins.ts
+++ b/src/client/lib/markdown-plugins.ts
@@ -11,15 +11,37 @@ import type { PluggableList } from "unified";
 
 const SANITIZE_SCHEMA = {
   ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    div: [
+      ...(defaultSchema.attributes?.div ?? []),
+      "className",
+      "dataType",
+      "dir",
+    ],
+    p: [...(defaultSchema.attributes?.p ?? []), "className", "dir"],
+    path: ["d", "fill"],
+    svg: [
+      "ariaHidden",
+      "className",
+      "fill",
+      "height",
+      "viewBox",
+      "width",
+      "xmlns",
+    ],
+  },
   tagNames: [
     ...(defaultSchema.tagNames ?? []),
     "abbr",
     "br",
     "details",
     "kbd",
+    "path",
     "sub",
     "summary",
     "sup",
+    "svg",
   ],
 };
 

--- a/src/client/utils/auto-expand.ts
+++ b/src/client/utils/auto-expand.ts
@@ -18,6 +18,19 @@ export const computeAutoExpandPaths = (nodes: FileNode[]): Set<string> => {
   return paths;
 };
 
+export const findFirstFile = (nodes: FileNode[]): string | null => {
+  for (const node of nodes) {
+    if (!node.children) {
+      return node.path;
+    }
+    const child = findFirstFile(node.children);
+    if (child) {
+      return child;
+    }
+  }
+  return null;
+};
+
 export const findNode = (
   nodes: FileNode[],
   path: string

--- a/src/client/utils/watch-handler.ts
+++ b/src/client/utils/watch-handler.ts
@@ -1,0 +1,32 @@
+import type { FileNode } from "@shared/types";
+
+import { findFirstFile, findNode } from "./auto-expand";
+
+interface WatchActions {
+  fetchAndSetContent: (path: string) => void;
+  setFiles: (files: FileNode[]) => void;
+  setSelectedPath: (path: string | null) => void;
+}
+
+export const handleFileChanged = (
+  eventPath: string,
+  selectedPath: string | null,
+  actions: WatchActions
+): void => {
+  if (eventPath === selectedPath) {
+    actions.fetchAndSetContent(eventPath);
+  }
+};
+
+export const handleTreeChanged = (
+  files: FileNode[],
+  selectedPath: string | null,
+  actions: WatchActions
+): void => {
+  actions.setFiles(files);
+
+  const stillExists = selectedPath && findNode(files, selectedPath);
+  if (!stillExists) {
+    actions.setSelectedPath(findFirstFile(files));
+  }
+};

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -5,6 +5,8 @@ import { Hono } from "hono";
 
 import { scanMarkdownFiles } from "./files";
 import { SecurityError, validateImagePath, validatePath } from "./security";
+import { createWatcher as defaultCreateWatcher } from "./watcher";
+import type { WatchCallback } from "./watcher";
 
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
   ".gif": "image/gif",
@@ -23,7 +25,7 @@ const readFile = async (filePath: string, baseDir: string): Promise<string> => {
 const readImage = async (
   filePath: string,
   baseDir: string
-): Promise<{ data: Buffer; contentType: string }> => {
+): Promise<{ contentType: string; data: Buffer }> => {
   const resolvedPath = validateImagePath(filePath, baseDir);
   const ext = path.extname(resolvedPath).toLowerCase();
   const contentType = IMAGE_CONTENT_TYPES[ext] ?? "application/octet-stream";
@@ -31,8 +33,74 @@ const readImage = async (
   return { contentType, data };
 };
 
-export const createApiRouter = (baseDir: string): Hono => {
+type WatcherFactory = (
+  baseDir: string,
+  onEvent: WatchCallback
+) => { close: () => void };
+
+interface ApiRouterOptions {
+  createWatcher?: WatcherFactory;
+}
+
+const TREE_DEBOUNCE_MS = 300;
+
+interface SSEMessage {
+  data: string;
+  event: string;
+}
+type SSEListener = (msg: SSEMessage) => void;
+
+const setupWatcher = (
+  baseDir: string,
+  factory: WatcherFactory,
+  broadcast: (msg: SSEMessage) => void
+) => {
+  let treeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  factory(baseDir, (event) => {
+    if (event.type === "change") {
+      broadcast({
+        data: JSON.stringify({ path: event.path }),
+        event: "file-changed",
+      });
+    } else {
+      if (treeDebounceTimer) {
+        clearTimeout(treeDebounceTimer);
+      }
+      treeDebounceTimer = setTimeout(async () => {
+        try {
+          const files = await scanMarkdownFiles(baseDir);
+          broadcast({
+            data: JSON.stringify({ files }),
+            event: "tree-changed",
+          });
+        } catch {
+          // scan failure is non-fatal
+        }
+      }, TREE_DEBOUNCE_MS);
+    }
+  });
+};
+
+export const createApiRouter = (
+  baseDir: string,
+  options?: ApiRouterOptions
+): Hono => {
   const api = new Hono();
+  const sseListeners = new Set<SSEListener>();
+  const encoder = new TextEncoder();
+
+  const broadcast = (msg: SSEMessage) => {
+    for (const listener of sseListeners) {
+      listener(msg);
+    }
+  };
+
+  setupWatcher(
+    baseDir,
+    options?.createWatcher ?? defaultCreateWatcher,
+    broadcast
+  );
 
   api.get("/api/files", async (c) => {
     try {
@@ -67,7 +135,7 @@ export const createApiRouter = (baseDir: string): Hono => {
     }
 
     try {
-      const { data, contentType } = await readImage(filePath, baseDir);
+      const { contentType, data } = await readImage(filePath, baseDir);
       return c.body(new Uint8Array(data), 200, { "Content-Type": contentType });
     } catch (error) {
       if (error instanceof SecurityError) {
@@ -75,6 +143,34 @@ export const createApiRouter = (baseDir: string): Hono => {
       }
       return c.json({ error: "Image not found" }, 404);
     }
+  });
+
+  api.get("/api/watch", (_c) => {
+    let listener: SSEListener | null = null;
+
+    const stream = new ReadableStream({
+      cancel() {
+        if (listener) {
+          sseListeners.delete(listener);
+        }
+      },
+      start(controller) {
+        listener = (msg) => {
+          controller.enqueue(
+            encoder.encode(`event: ${msg.event}\ndata: ${msg.data}\n\n`)
+          );
+        };
+        sseListeners.add(listener);
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "Content-Type": "text/event-stream",
+      },
+    });
   });
 
   return api;

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -16,17 +16,28 @@ const openInBrowser = async (url: string): Promise<void> => {
   await mod.default(url);
 };
 
+const DISCONNECT_GRACE_MS = 2000;
+
 const registerLifecycle = (app: Hono, onDisconnect: () => void) => {
   let connections = 0;
+  let graceTimer: ReturnType<typeof setTimeout> | null = null;
 
   app.get("/api/lifecycle", (_c) => {
     connections += 1;
+    if (graceTimer) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
 
     const stream = new ReadableStream({
       cancel() {
         connections -= 1;
         if (connections === 0) {
-          onDisconnect();
+          graceTimer = setTimeout(() => {
+            if (connections === 0) {
+              onDisconnect();
+            }
+          }, DISCONNECT_GRACE_MS);
         }
       },
       start(controller) {

--- a/src/server/files.ts
+++ b/src/server/files.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import type { FileNode } from "@shared/types";
 
-const IGNORED_DIRS = new Set([
+export const IGNORED_DIRS = new Set([
   "node_modules",
   ".git",
   ".hg",

--- a/src/server/watcher.ts
+++ b/src/server/watcher.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { IGNORED_DIRS } from "./files";
+
+export type WatchEventType = "add" | "change" | "unlink";
+export interface WatchEvent {
+  path: string;
+  type: WatchEventType;
+}
+export type WatchCallback = (event: WatchEvent) => void;
+
+const DEBOUNCE_MS = 200;
+
+const isIgnored = (filePath: string): boolean => {
+  const parts = filePath.split(path.sep);
+  return parts.some((part) => IGNORED_DIRS.has(part));
+};
+
+const isMarkdown = (filePath: string): boolean =>
+  path.extname(filePath) === ".md";
+
+const isSafePath = (baseDir: string, filePath: string): boolean => {
+  const normalized = path.normalize(filePath);
+  const resolved = path.resolve(baseDir, normalized);
+  return resolved.startsWith(baseDir + path.sep) || resolved === baseDir;
+};
+
+const resolveEventType = (
+  fullPath: string,
+  normalized: string,
+  knownFiles: Set<string>
+): WatchEventType => {
+  if (!fs.existsSync(fullPath)) {
+    knownFiles.delete(normalized);
+    return "unlink";
+  }
+  if (knownFiles.has(normalized)) {
+    return "change";
+  }
+  knownFiles.add(normalized);
+  return "add";
+};
+
+const scanExisting = (dir: string, knownFiles: Set<string>, rel = ""): void => {
+  try {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory() && !IGNORED_DIRS.has(entry.name)) {
+        scanExisting(
+          path.join(dir, entry.name),
+          knownFiles,
+          path.join(rel, entry.name)
+        );
+      } else if (entry.isFile() && isMarkdown(entry.name)) {
+        knownFiles.add(path.join(rel, entry.name));
+      }
+    }
+  } catch {
+    // ディレクトリ読み取りエラーは無視
+  }
+};
+
+export const createWatcher = (
+  baseDir: string,
+  onEvent: WatchCallback
+): { close: () => void } => {
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  const knownFiles = new Set<string>();
+
+  scanExisting(baseDir, knownFiles);
+
+  const watcher = fs.watch(baseDir, { recursive: true }, (_event, filename) => {
+    if (!filename) {
+      return;
+    }
+
+    const normalized = path.normalize(filename);
+    if (!isMarkdown(normalized) || isIgnored(normalized)) {
+      return;
+    }
+    if (!isSafePath(baseDir, normalized)) {
+      return;
+    }
+
+    if (timers.has(normalized)) {
+      clearTimeout(timers.get(normalized));
+    }
+
+    timers.set(
+      normalized,
+      setTimeout(() => {
+        timers.delete(normalized);
+        const fullPath = path.resolve(baseDir, normalized);
+        const type = resolveEventType(fullPath, normalized, knownFiles);
+        onEvent({ path: normalized, type });
+      }, DEBOUNCE_MS)
+    );
+  });
+
+  return {
+    close: () => {
+      watcher.close();
+      for (const timer of timers.values()) {
+        clearTimeout(timer);
+      }
+      timers.clear();
+    },
+  };
+};

--- a/tests/markdown-pipeline.test.ts
+++ b/tests/markdown-pipeline.test.ts
@@ -98,6 +98,26 @@ describe("markdown pipeline", () => {
     });
   });
 
+  describe("gitHub Alerts", () => {
+    it("[!NOTE] アラートがレンダリングされる", async () => {
+      const html = await renderMarkdown("> [!NOTE]\n> これは補足情報です。");
+      expect(html).toContain("markdown-alert");
+      expect(html).toContain("markdown-alert-note");
+    });
+
+    it("[!WARNING] アラートがレンダリングされる", async () => {
+      const html = await renderMarkdown(
+        "> [!WARNING]\n> 注意が必要な情報です。"
+      );
+      expect(html).toContain("markdown-alert-warning");
+    });
+
+    it("アラートの SVG アイコンが保持される", async () => {
+      const html = await renderMarkdown("> [!NOTE]\n> テスト");
+      expect(html).toContain("<svg");
+    });
+  });
+
   describe("脚注 (#3)", () => {
     it("脚注が doc-endnotes セクションとしてレンダリングされる", async () => {
       const html = await renderMarkdown("テキスト[^1]\n\n[^1]: 脚注の内容");

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -29,3 +29,5 @@ export const withTmpDir = async (
     removeTmpDir(tmpDir);
   }
 };
+
+export { setTimeout as delay } from "node:timers/promises";

--- a/tests/use-scroll-restore.test.ts
+++ b/tests/use-scroll-restore.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+
+import { useScrollRestore } from "@/hooks/use-scroll-restore";
+
+describe("hook: useScrollRestore", () => {
+  it("selectedPath 変更時 → scrollTop = 0", () => {
+    const scrollRef = { current: { scrollTop: 150 } };
+
+    const { rerender } = renderHook(
+      ({ selectedPath }) =>
+        useScrollRestore(
+          scrollRef as unknown as React.RefObject<HTMLDivElement>,
+          selectedPath
+        ),
+      { initialProps: { selectedPath: "a.md" } }
+    );
+
+    rerender({ selectedPath: "b.md" });
+    expect(scrollRef.current.scrollTop).toBe(0);
+  });
+
+  it("同一パスの再レンダリング → scrollTop が変更されない", () => {
+    const scrollRef = { current: { scrollTop: 200 } };
+
+    const { rerender } = renderHook(
+      ({ selectedPath }) =>
+        useScrollRestore(
+          scrollRef as unknown as React.RefObject<HTMLDivElement>,
+          selectedPath
+        ),
+      { initialProps: { selectedPath: "a.md" } }
+    );
+
+    rerender({ selectedPath: "a.md" });
+    expect(scrollRef.current.scrollTop).toBe(200);
+  });
+});

--- a/tests/watch-api.test.ts
+++ b/tests/watch-api.test.ts
@@ -1,0 +1,131 @@
+import { setTimeout as delay } from "node:timers/promises";
+
+import { createApiRouter } from "@server/api";
+import type { WatchCallback, WatchEvent } from "@server/watcher";
+
+import { createFile, withTmpDir } from "./test-utils";
+
+interface MockWatcher {
+  close: ReturnType<typeof vi.fn>;
+  emit: (event: WatchEvent) => void;
+}
+
+const createMockWatcherFactory = () => {
+  const watchers: MockWatcher[] = [];
+
+  const factory = (_baseDir: string, onEvent: WatchCallback) => {
+    const closeFn = vi.fn();
+    const mock: MockWatcher = {
+      close: closeFn,
+      emit: (event: WatchEvent) => onEvent(event),
+    };
+    watchers.push(mock);
+    return { close: closeFn };
+  };
+
+  return { factory, watchers };
+};
+
+const readChunks = async (
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  events: string[],
+  count: number
+): Promise<void> => {
+  while (events.length < count) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    const parts = decoder
+      .decode(value)
+      .split("\n\n")
+      .filter((p) => p.trim());
+    events.push(...parts);
+  }
+};
+
+const collectSSEEvents = async (
+  stream: ReadableStream<Uint8Array>,
+  count: number
+): Promise<string[]> => {
+  const reader = stream.getReader();
+  const events: string[] = [];
+
+  try {
+    await readChunks(reader, new TextDecoder(), events, count);
+  } finally {
+    await reader.cancel();
+  }
+
+  return events;
+};
+
+const setupWatchApp = (tmpDir: string) => {
+  createFile(tmpDir, "test.md", "# Test");
+  const { factory, watchers } = createMockWatcherFactory();
+  const app = createApiRouter(tmpDir, { createWatcher: factory });
+  return { app, watchers };
+};
+
+const requestWatch = async (app: ReturnType<typeof createApiRouter>) => {
+  const res = await app.request("/api/watch");
+  expect(res.body).toBeTruthy();
+  return res.body as ReadableStream<Uint8Array>;
+};
+
+describe("gET /api/watch", () => {
+  it("sSE ストリーム (text/event-stream) を返す", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const { app } = setupWatchApp(tmpDir);
+      const res = await app.request("/api/watch");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+    });
+  });
+
+  it("change イベント → file-changed SSE イベント送信", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const { app, watchers } = setupWatchApp(tmpDir);
+      const body = await requestWatch(app);
+
+      await delay(50);
+      watchers[0].emit({ path: "test.md", type: "change" });
+
+      const events = await collectSSEEvents(body, 1);
+      expect(events.find((e) => e.includes("event: file-changed"))).toContain(
+        '"path":"test.md"'
+      );
+    });
+  });
+
+  it("add イベント → tree-changed SSE イベント送信", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const { app, watchers } = setupWatchApp(tmpDir);
+      const body = await requestWatch(app);
+
+      await delay(50);
+      watchers[0].emit({ path: "new.md", type: "add" });
+
+      const events = await collectSSEEvents(body, 1);
+      expect(events.find((e) => e.includes("event: tree-changed"))).toContain(
+        '"files"'
+      );
+    });
+  });
+
+  it("unlink イベント → tree-changed SSE イベント送信", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const { app, watchers } = setupWatchApp(tmpDir);
+      const body = await requestWatch(app);
+
+      await delay(50);
+      watchers[0].emit({ path: "test.md", type: "unlink" });
+
+      const events = await collectSSEEvents(body, 1);
+      expect(events.find((e) => e.includes("event: tree-changed"))).toContain(
+        '"files"'
+      );
+    });
+  });
+});

--- a/tests/watch-handler.test.ts
+++ b/tests/watch-handler.test.ts
@@ -1,0 +1,97 @@
+import type { FileNode } from "@shared/types";
+
+import { handleFileChanged, handleTreeChanged } from "@/utils/watch-handler";
+
+describe("watch-handler: handleFileChanged", () => {
+  it("eventPath === selectedPath → fetchAndSetContent が呼ばれる", () => {
+    const actions = {
+      fetchAndSetContent: vi.fn(),
+      setFiles: vi.fn(),
+      setSelectedPath: vi.fn(),
+    };
+
+    handleFileChanged("docs/README.md", "docs/README.md", actions);
+
+    expect(actions.fetchAndSetContent).toHaveBeenCalledWith("docs/README.md");
+  });
+
+  it("eventPath !== selectedPath → 何も呼ばれない", () => {
+    const actions = {
+      fetchAndSetContent: vi.fn(),
+      setFiles: vi.fn(),
+      setSelectedPath: vi.fn(),
+    };
+
+    handleFileChanged("docs/other.md", "docs/README.md", actions);
+
+    expect(actions.fetchAndSetContent).not.toHaveBeenCalled();
+    expect(actions.setFiles).not.toHaveBeenCalled();
+    expect(actions.setSelectedPath).not.toHaveBeenCalled();
+  });
+});
+
+describe("watch-handler: handleTreeChanged", () => {
+  const tree: FileNode[] = [
+    {
+      children: [
+        { name: "guide.md", path: "docs/guide.md" },
+        { name: "api.md", path: "docs/api.md" },
+      ],
+      name: "docs",
+      path: "docs",
+    },
+    { name: "README.md", path: "README.md" },
+  ];
+
+  it("selectedPath がツリーに存在 → setFiles のみ呼ばれる", () => {
+    const actions = {
+      fetchAndSetContent: vi.fn(),
+      setFiles: vi.fn(),
+      setSelectedPath: vi.fn(),
+    };
+
+    handleTreeChanged(tree, "docs/guide.md", actions);
+
+    expect(actions.setFiles).toHaveBeenCalledWith(tree);
+    expect(actions.setSelectedPath).not.toHaveBeenCalled();
+  });
+
+  it("selectedPath がツリーに存在しない → setFiles + setSelectedPath が呼ばれる", () => {
+    const actions = {
+      fetchAndSetContent: vi.fn(),
+      setFiles: vi.fn(),
+      setSelectedPath: vi.fn(),
+    };
+
+    handleTreeChanged(tree, "deleted.md", actions);
+
+    expect(actions.setFiles).toHaveBeenCalledWith(tree);
+    expect(actions.setSelectedPath).toHaveBeenCalledWith("docs/guide.md");
+  });
+
+  it("selectedPath が null → setFiles + setSelectedPath が呼ばれる", () => {
+    const actions = {
+      fetchAndSetContent: vi.fn(),
+      setFiles: vi.fn(),
+      setSelectedPath: vi.fn(),
+    };
+
+    handleTreeChanged(tree, null, actions);
+
+    expect(actions.setFiles).toHaveBeenCalledWith(tree);
+    expect(actions.setSelectedPath).toHaveBeenCalledWith("docs/guide.md");
+  });
+
+  it("空のツリー → setFiles + setSelectedPath(null) が呼ばれる", () => {
+    const actions = {
+      fetchAndSetContent: vi.fn(),
+      setFiles: vi.fn(),
+      setSelectedPath: vi.fn(),
+    };
+
+    handleTreeChanged([], "docs/guide.md", actions);
+
+    expect(actions.setFiles).toHaveBeenCalledWith([]);
+    expect(actions.setSelectedPath).toHaveBeenCalledWith(null);
+  });
+});

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { createWatcher } from "@server/watcher";
+
+import { createFile, delay, withTmpDir } from "./test-utils";
+
+const waitForEvent = async (
+  cb: ReturnType<typeof vi.fn>,
+  timeout = 2000
+): Promise<void> => {
+  await vi.waitFor(() => expect(cb.mock.calls.length).toBeGreaterThan(0), {
+    interval: 50,
+    timeout,
+  });
+};
+
+describe("server: createWatcher", () => {
+  it(".md ファイルの変更を検知する", async () => {
+    await withTmpDir(async (tmpDir) => {
+      createFile(tmpDir, "test.md", "initial");
+      const cb = vi.fn();
+      const { close } = createWatcher(tmpDir, cb);
+
+      try {
+        await delay(100);
+        fs.writeFileSync(path.join(tmpDir, "test.md"), "updated");
+
+        await waitForEvent(cb);
+        expect(cb).toHaveBeenCalledWith(
+          expect.objectContaining({ path: "test.md", type: "change" })
+        );
+      } finally {
+        close();
+      }
+    });
+  });
+
+  it(".md ファイルの追加を検知する", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const cb = vi.fn();
+      const { close } = createWatcher(tmpDir, cb);
+
+      try {
+        await delay(100);
+        createFile(tmpDir, "new.md", "hello");
+
+        await waitForEvent(cb);
+        expect(cb).toHaveBeenCalledWith(
+          expect.objectContaining({ path: "new.md", type: "add" })
+        );
+      } finally {
+        close();
+      }
+    });
+  });
+
+  it(".md ファイルの削除を検知する", async () => {
+    await withTmpDir(async (tmpDir) => {
+      createFile(tmpDir, "delete-me.md", "bye");
+      const cb = vi.fn();
+      const { close } = createWatcher(tmpDir, cb);
+
+      try {
+        await delay(100);
+        fs.unlinkSync(path.join(tmpDir, "delete-me.md"));
+
+        await waitForEvent(cb);
+        expect(cb).toHaveBeenCalledWith(
+          expect.objectContaining({ path: "delete-me.md", type: "unlink" })
+        );
+      } finally {
+        close();
+      }
+    });
+  });
+
+  it(".md 以外のファイルは無視する", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const cb = vi.fn();
+      const { close } = createWatcher(tmpDir, cb);
+
+      try {
+        await delay(100);
+        createFile(tmpDir, "readme.txt", "hello");
+        await delay(500);
+        expect(cb).not.toHaveBeenCalled();
+      } finally {
+        close();
+      }
+    });
+  });
+
+  it("iGNORED_DIRS 内の変更は無視する", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const cb = vi.fn();
+      const { close } = createWatcher(tmpDir, cb);
+
+      try {
+        await delay(100);
+        createFile(tmpDir, "node_modules/pkg/README.md", "hello");
+        await delay(500);
+        expect(cb).not.toHaveBeenCalled();
+      } finally {
+        close();
+      }
+    });
+  });
+
+  it("close() で監視停止する", async () => {
+    await withTmpDir(async (tmpDir) => {
+      createFile(tmpDir, "test.md", "initial");
+      const cb = vi.fn();
+      const { close } = createWatcher(tmpDir, cb);
+
+      await delay(100);
+      close();
+
+      fs.writeFileSync(path.join(tmpDir, "test.md"), "after close");
+      await delay(500);
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  it("デバウンス: 連続変更が 1 回にまとまる", async () => {
+    await withTmpDir(async (tmpDir) => {
+      createFile(tmpDir, "debounce.md", "v0");
+      const cb = vi.fn();
+      const { close } = createWatcher(tmpDir, cb);
+
+      try {
+        await delay(100);
+        for (const v of ["v1", "v2", "v3"]) {
+          fs.writeFileSync(path.join(tmpDir, "debounce.md"), v);
+        }
+        await delay(500);
+        // eslint-disable-next-line vitest/prefer-called-times
+        expect(cb).toHaveBeenCalledOnce();
+      } finally {
+        close();
+      }
+    });
+  });
+
+  it("baseDir 外のパスが除外される", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const cb = vi.fn();
+      const { close } = createWatcher(tmpDir, cb);
+
+      try {
+        await delay(100);
+        await delay(500);
+        expect(cb).not.toHaveBeenCalled();
+      } finally {
+        close();
+      }
+    });
+  });
+
+  it("サブディレクトリ内の .md ファイル変更を検知する", async () => {
+    await withTmpDir(async (tmpDir) => {
+      createFile(tmpDir, "docs/guide.md", "initial");
+      const cb = vi.fn();
+      const { close } = createWatcher(tmpDir, cb);
+
+      try {
+        await delay(100);
+        fs.writeFileSync(path.join(tmpDir, "docs/guide.md"), "updated");
+
+        await waitForEvent(cb);
+        expect(cb).toHaveBeenCalledWith(
+          expect.objectContaining({ path: "docs/guide.md", type: "change" })
+        );
+      } finally {
+        close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## 概要
エディタで Markdown ファイルを保存するだけでプレビューが即座に反映されるホットリロード機能を追加。
ファイルツリーの変更（追加/削除）にも対応し、スクロール位置も適切に保持される。
Closes #38

## 設計判断
- ファイル監視に `node:fs.watch` (recursive) を採用（外部依存不要、macOS は FSEvents で安定動作）
- 新規 `/api/watch` SSE エンドポイントで配信（既存の `/api/lifecycle` は接続管理専用で責務分離）
- watcher をルーター初期化時に 1 つだけ作成し全 SSE 接続で共有（接続数に依存しない）
- イベントハンドラを純粋関数として抽出しユニットテスト可能に（watch-handler.ts）
- ツリー再スキャンをルーターレベルで一元化（複数クライアント接続時の重複スキャン防止）

## 変更内容
- `src/server/watcher.ts`: ファイル監視モジュール（デバウンス 200ms、パス正規化、IGNORED_DIRS フィルタ）
- `src/server/api.ts`: `/api/watch` SSE エンドポイント（DI 対応、ツリーデバウンス 300ms）
- `src/client/hooks/use-watch.ts`: SSE 購読フック
- `src/client/hooks/use-scroll-restore.ts`: スクロール位置保存フック
- `src/client/utils/watch-handler.ts`: イベントハンドラ純粋関数
- `src/server/cli.ts`: ブラウザリロード時の切断猶予（2秒）
- `src/client/lib/markdown-plugins.ts`: rehype-sanitize スキーマに SVG/class 追加（GitHub Alerts 修正）

## テスト計画
- [ ] `nr dev` で起動 → エディタで `.md` を編集 → プレビューが自動更新
- [ ] `.md` ファイルを新規作成 → ファイルツリーに追加表示
- [ ] `.md` ファイルを削除 → ファイルツリーから除外、別ファイルが自動選択
- [ ] 長いドキュメントをスクロール → 同ファイル更新後もスクロール位置維持
- [ ] ブラウザをリロード → サーバーが落ちずに再接続
- [ ] `> [!NOTE]` アラートが正しくスタイル付きで表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)