### PR TITLE
chore: open パッケージを自前実装に置き換え

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "hono": "^4.12.7",
     "katex": "^0.16.38",
     "mermaid": "^11.13.0",
-    "open": "^11.0.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       mermaid:
         specifier: ^11.13.0
         version: 11.13.0
-      open:
-        specifier: ^11.0.0
-        version: 11.0.0
       rehype-autolink-headings:
         specifier: ^7.1.0
         version: 7.1.0

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -8,13 +8,9 @@ import { program } from "commander";
 import { Hono } from "hono";
 
 import { createApiRouter } from "./api";
+import { openInBrowser } from "./open-browser";
 
 const currentDir = import.meta.dirname;
-
-const openInBrowser = async (url: string): Promise<void> => {
-  const mod = await import("open");
-  await mod.default(url);
-};
 
 const DISCONNECT_GRACE_MS = 2000;
 

--- a/src/server/open-browser.ts
+++ b/src/server/open-browser.ts
@@ -1,0 +1,21 @@
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+const getCommand = (url: string) => {
+  if (process.platform === "darwin") {
+    return { args: [url], command: "open" };
+  }
+
+  if (process.platform === "win32") {
+    return { args: ["/c", "start", "", url], command: "cmd" };
+  }
+
+  return { args: [url], command: "xdg-open" };
+};
+
+export const openInBrowser = async (url: string): Promise<void> => {
+  const { args, command } = getCommand(url);
+  await execFile(command, args);
+};

--- a/tests/open-browser.test.ts
+++ b/tests/open-browser.test.ts
@@ -1,0 +1,66 @@
+import { openInBrowser } from "@server/open-browser";
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+}));
+
+vi.mock(import("node:child_process"), () => ({
+  execFile: mockExecFile,
+}));
+
+vi.mock(import("node:util"), () => ({
+  promisify: () => mockExecFile,
+}));
+
+describe("server: openInBrowser", () => {
+  // eslint-disable-next-line jest/no-hooks -- mock reset and global cleanup required
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    mockExecFile.mockReset();
+  });
+
+  it("darwin で open コマンドが URL を引数に呼ばれる", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    mockExecFile.mockResolvedValue(null);
+
+    await openInBrowser("http://localhost:4649");
+
+    expect(mockExecFile).toHaveBeenCalledWith("open", [
+      "http://localhost:4649",
+    ]);
+  });
+
+  it("linux で xdg-open コマンドが URL を引数に呼ばれる", async () => {
+    vi.stubGlobal("process", { ...process, platform: "linux" });
+    mockExecFile.mockResolvedValue(null);
+
+    await openInBrowser("http://localhost:4649");
+
+    expect(mockExecFile).toHaveBeenCalledWith("xdg-open", [
+      "http://localhost:4649",
+    ]);
+  });
+
+  it("win32 で cmd 経由で start が呼ばれる", async () => {
+    vi.stubGlobal("process", { ...process, platform: "win32" });
+    mockExecFile.mockResolvedValue(null);
+
+    await openInBrowser("http://localhost:4649");
+
+    expect(mockExecFile).toHaveBeenCalledWith("cmd", [
+      "/c",
+      "start",
+      "",
+      "http://localhost:4649",
+    ]);
+  });
+
+  it("コマンド実行エラー時に reject する", async () => {
+    vi.stubGlobal("process", { ...process, platform: "darwin" });
+    mockExecFile.mockRejectedValue(new Error("command not found"));
+
+    await expect(openInBrowser("http://localhost:4649")).rejects.toThrow(
+      "command not found"
+    );
+  });
+});


### PR DESCRIPTION
## 概要
bunx specv 実行時に open パッケージ (v11) が wsl-utils の動的 import に失敗しブラウザが開かない問題を解消。
node:child_process の execFile でプラットフォーム固有コマンドを直接呼び出す自前実装に置き換え。

## 設計判断
- execFile を採用（exec と比較して、引数を配列で渡すためシェルインジェクションを根本的に防止）
- promisify で Promise 化（lint ルール avoid-new / prefer-await-to-callbacks に適合）
- プラットフォーム分岐を getCommand 関数に分離（no-nested-ternary 回避、テスタビリティ向上）

## 変更内容
- `src/server/open-browser.ts` を新規作成（darwin: open、linux: xdg-open、win32: cmd /c start）
- `tests/open-browser.test.ts` を新規作成（4 テストケース）
- `src/server/cli.ts` の inline 実装を import に切り替え
- `package.json` から open 依存を削除

## テスト計画
- [ ] `nr test` で全 108 テストがパスすること
- [ ] `nr typecheck` で型エラーがないこと
- [ ] `nr check` で lint エラーがないこと
- [ ] `nr build` でビルドが成功すること