### PR TITLE
fix: ブラウザ起動失敗時のエラーメッセージを改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,14 @@ A CLI tool that previews Markdown files in the current directory with GitHub-sty
 - GitHub dark theme color scheme
 - Automatic port detection (tries next port on conflict)
 
-## Install
-
-```bash
-npm install -g specv
-```
-
 ## Usage
 
 ```bash
 # Preview .md files in the current directory
-specv
+npx specv@latest
 
 # Specify a port
-specv -p 3000
+npx specv@latest -p 3000
 ```
 
 A browser window opens automatically, rendering your Markdown files with GitHub-style formatting.

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -108,8 +108,8 @@ program
 
           try {
             await openInBrowser(url);
-          } catch (error: unknown) {
-            console.error("Failed to open browser:", error);
+          } catch {
+            console.log(`Open ${url} in your browser`);
           }
         }
       );


### PR DESCRIPTION
## 概要

ブラウザ自動起動が失敗した際のエラーメッセージを、ユーザーが次のアクションを取れる案内に改善。

## バグ詳細

- **症状**: `bunx specv` で古いキャッシュバージョンが使われた場合、`wsl-utils` エラーのスタックトレースが表示される
- **再現条件**: bunx がv0.4.0以前のバージョンをキャッシュしている環境
- **再現方法**: キャッシュが残った状態で `bunx specv` を実行

## 原因

catch ブロックで `console.error` にエラーオブジェクトをそのまま渡しており、ユーザーにとって不要なスタックトレースが表示されていた。

## 修正内容

- catch ブロックでスタックトレースの代わりに `Open <url> in your browser` を表示
- README を `npx specv@latest` に変更し、常に最新版を使用するよう案内
- グローバルインストール (`npm i -g`) の記載を削除

## 影響範囲

- CLI のブラウザ起動失敗時のメッセージ表示
- README のインストール・使用方法の記載

## テスト計画

- [x] `nr test` — ユニットテスト通過
- [x] `nr typecheck` — 型チェック通過
- [x] `nr check` — lint 通過
- [x] `nr build` — ビルド成功