### PR TITLE
feat: レスポンシブデザイン対応と QR コード表示機能を追加 (#47, #42)

### DIFF
--- a/e2e/responsive.test.ts
+++ b/e2e/responsive.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+const MOBILE_VIEWPORT = { height: 667, width: 375 };
+const DESKTOP_VIEWPORT = { height: 900, width: 1280 };
+
+test.describe("モバイルビューポート", () => {
+  test.use({ viewport: MOBILE_VIEWPORT });
+
+  test("サイドバーが初期非表示", async ({ page }) => {
+    await page.goto("/");
+    // サイドバーのタイトルが見えない
+    await expect(page.getByText("specv")).not.toBeVisible();
+    // Show sidebar ボタンが見える
+    await expect(page.getByTitle(/Show sidebar/i)).toBeVisible();
+  });
+
+  test("トグルでオーバーレイドロワー表示", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTitle(/Show sidebar/i).click();
+
+    // サイドバーが表示される
+    await expect(page.getByText("specv")).toBeVisible();
+    // バックドロップが表示される
+    await expect(
+      page.locator("[data-testid='sidebar-backdrop']")
+    ).toBeVisible();
+  });
+
+  test("バックドロップクリックで閉じる", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTitle(/Show sidebar/i).click();
+    await expect(page.getByText("specv")).toBeVisible();
+
+    // バックドロップをクリック
+    await page.locator("[data-testid='sidebar-backdrop']").click();
+    await expect(page.getByText("specv")).not.toBeVisible();
+  });
+
+  test("ファイル選択でサイドバーが閉じる", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTitle(/Show sidebar/i).click();
+    await expect(page.getByText("specv")).toBeVisible();
+
+    // ファイルを選択
+    await page.getByText("README.md").click();
+    await expect(page.getByText("specv")).not.toBeVisible();
+  });
+
+  test("Quick Open がモバイル幅に収まる", async ({ page }) => {
+    await page.goto("/");
+    // ⌘P で Quick Open を開く
+    await page.keyboard.press("Meta+p");
+    const dialog = page.locator("[class*='max-w-']");
+    await expect(dialog.first()).toBeVisible();
+
+    // 幅がビューポートに収まっているか
+    const box = await dialog.first().boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeLessThanOrEqual(MOBILE_VIEWPORT.width);
+  });
+});
+
+test.describe("デスクトップビューポート", () => {
+  test.use({ viewport: DESKTOP_VIEWPORT });
+
+  test("サイドバーが初期表示される", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("specv")).toBeVisible();
+    await expect(page.getByTitle(/Hide sidebar/i)).toBeVisible();
+  });
+
+  test("リサイズセパレーターが表示される", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("separator")).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "dev": "pnpm run dev:server & pnpm run dev:client",
     "dev:client": "vite",
+    "dev:host": "tsx src/server/cli.ts --host & SPECV_HOST=1 vite",
     "dev:server": "tsx src/server/cli.ts",
     "build:client": "vite build",
     "build:server": "tsup src/server/cli.ts --format esm --out-dir dist/server --dts",
@@ -47,6 +48,7 @@
     "hono": "^4.12.7",
     "katex": "^0.16.38",
     "mermaid": "^11.13.0",
+    "qrcode-terminal": "^0.12.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
@@ -65,6 +67,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^25.4.0",
+    "@types/qrcode-terminal": "^0.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       mermaid:
         specifier: ^11.13.0
         version: 11.13.0
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0
       rehype-autolink-headings:
         specifier: ^7.1.0
         version: 7.1.0
@@ -75,6 +78,9 @@ importers:
       '@types/node':
         specifier: ^25.4.0
         version: 25.4.0
+      '@types/qrcode-terminal':
+        specifier: ^0.12.2
+        version: 0.12.2
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -1726,6 +1732,9 @@ packages:
 
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
+
+  '@types/qrcode-terminal@0.12.2':
+    resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -3563,6 +3572,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode-terminal@0.12.0:
+    resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
+    hasBin: true
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -5666,6 +5679,8 @@ snapshots:
       undici-types: 7.18.2
 
   '@types/prismjs@1.26.6': {}
+
+  '@types/qrcode-terminal@0.12.2': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -7821,6 +7836,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   punycode@2.3.1: {}
+
+  qrcode-terminal@0.12.0: {}
 
   qs@6.15.0:
     dependencies:

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -11,6 +11,7 @@ import { QuickOpen } from "./components/quick-open";
 import { Source } from "./components/source";
 import { ThemeToggle } from "./components/theme-toggle";
 import { Button } from "./components/ui/button";
+import { useIsMobile } from "./hooks/use-is-mobile";
 import { useResizable } from "./hooks/use-resizable";
 import { useScrollRestore } from "./hooks/use-scroll-restore";
 import { useWatch } from "./hooks/use-watch";
@@ -102,18 +103,23 @@ const useHotkeys = (
 };
 
 const useSidebar = (
-  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>
+  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>,
+  isMobile: boolean
 ) => {
   const sidebarRef = useRef<HTMLElement>(null);
   const { isDragging, onDoubleClick, onMouseDown, width } =
     useResizable(sidebarRef);
 
   return {
+    handleCloseSidebar: useCallback(
+      () => setSidebarOpen(false),
+      [setSidebarOpen]
+    ),
     handleToggleSidebar: useCallback(
       () => setSidebarOpen((v) => !v),
       [setSidebarOpen]
     ),
-    isDragging,
+    isDragging: isMobile ? false : isDragging,
     onDoubleClick,
     onMouseDown,
     sidebarRef,
@@ -143,8 +149,9 @@ const useContentState = () => {
 };
 
 const useAppState = () => {
+  const isMobile = useIsMobile();
   const [viewMode, setViewMode] = useState<ViewMode>("preview");
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(!isMobile);
   const [quickOpenVisible, setQuickOpenVisible] = useState(false);
 
   useHotkeys(setQuickOpenVisible, setSidebarOpen);
@@ -152,7 +159,8 @@ const useAppState = () => {
   return {
     ...useAppHandlers(setViewMode, setQuickOpenVisible),
     ...useContentState(),
-    ...useSidebar(setSidebarOpen),
+    ...useSidebar(setSidebarOpen, isMobile),
+    isMobile,
     quickOpenVisible,
     sidebarOpen,
     viewMode,
@@ -165,11 +173,13 @@ export const App = () => {
   const {
     content,
     files,
+    handleCloseSidebar,
     handleCloseQuickOpen,
     handleSetPreview,
     handleSetSource,
     handleToggleSidebar,
     isDragging,
+    isMobile,
     onDoubleClick,
     onMouseDown,
     quickOpenVisible,
@@ -182,6 +192,16 @@ export const App = () => {
     viewMode,
   } = useAppState();
 
+  const handleSelect = useCallback(
+    (path: string) => {
+      setSelectedPath(path);
+      if (isMobile) {
+        handleCloseSidebar();
+      }
+    },
+    [setSelectedPath, isMobile, handleCloseSidebar]
+  );
+
   return (
     <div
       className={cn(
@@ -189,35 +209,72 @@ export const App = () => {
         isDragging && "select-none cursor-col-resize"
       )}
     >
+      {/* バックドロップ（モバイル） */}
+      {isMobile && sidebarOpen && (
+        <button
+          type="button"
+          className="fixed inset-0 z-30 bg-black/50 border-none p-0 cursor-default"
+          data-testid="sidebar-backdrop"
+          onClick={handleCloseSidebar}
+          aria-label="Close sidebar"
+        />
+      )}
+
       {/* サイドバー */}
       {sidebarOpen && (
         <>
           <aside
             ref={sidebarRef}
             className={cn(
-              "shrink-0 border-r border-border overflow-y-auto p-4 bg-secondary transition-[width] duration-200",
-              isDragging && "!transition-none"
+              "shrink-0 border-r border-border overflow-y-auto p-4 bg-secondary",
+              isMobile
+                ? "fixed inset-y-0 left-0 z-40 w-[280px]"
+                : "transition-[width] duration-200",
+              !isMobile && isDragging && "!transition-none"
             )}
-            style={{ width: sidebarWidth }}
+            style={isMobile ? undefined : { width: sidebarWidth }}
           >
-            <h1 className="text-lg font-bold mb-4">specv</h1>
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <img
+                  src="/favicon.png"
+                  alt=""
+                  width={20}
+                  height={20}
+                  className="rounded-full"
+                />
+                <h1 className="text-lg font-bold">specv</h1>
+              </div>
+              {isMobile && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleCloseSidebar}
+                  title="Close sidebar"
+                >
+                  <PanelLeftClose size={16} />
+                </Button>
+              )}
+            </div>
             <FileTree
               files={files}
               selectedPath={selectedPath}
-              onSelect={setSelectedPath}
+              onSelect={handleSelect}
             />
           </aside>
-          <div
-            role="separator"
-            aria-orientation="vertical"
-            className={cn(
-              "relative w-1 shrink-0 cursor-col-resize hover:bg-ring transition-colors",
-              "before:absolute before:inset-y-0 before:-left-1 before:-right-1",
-              isDragging && "bg-ring"
-            )}
-            onDoubleClick={onDoubleClick}
-            onMouseDown={onMouseDown}
-          />
+          {!isMobile && (
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              className={cn(
+                "relative w-1 shrink-0 cursor-col-resize hover:bg-ring transition-colors",
+                "before:absolute before:inset-y-0 before:-left-1 before:-right-1",
+                isDragging && "bg-ring"
+              )}
+              onDoubleClick={onDoubleClick}
+              onMouseDown={onMouseDown}
+            />
+          )}
         </>
       )}
 
@@ -263,12 +320,17 @@ export const App = () => {
             </Button>
           </div>
           <div className="flex-1" />
-          <span className="text-sm text-muted-foreground">{selectedPath}</span>
+          <span className="text-sm text-muted-foreground truncate hidden md:inline">
+            {selectedPath}
+          </span>
           <ThemeToggle />
         </header>
 
         {/* コンテンツ */}
-        <div ref={scrollRef} className="flex-1 overflow-y-auto px-8 py-8">
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-y-auto px-4 py-4 md:px-8 md:py-8"
+        >
           {renderContent(selectedPath, viewMode, content, setSelectedPath)}
         </div>
       </main>
@@ -276,7 +338,7 @@ export const App = () => {
         files={files}
         open={quickOpenVisible}
         onClose={handleCloseQuickOpen}
-        onSelect={setSelectedPath}
+        onSelect={handleSelect}
       />
     </div>
   );

--- a/src/client/components/preview.tsx
+++ b/src/client/components/preview.tsx
@@ -25,7 +25,23 @@ const CopyButton = ({ text }: { text: string }) => {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(text);
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // HTTP 環境（スマホからの LAN アクセス等）では clipboard API が使えないためフォールバック
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      textarea.style.top = "-9999px";
+      textarea.style.opacity = "0";
+      document.body.append(textarea);
+      textarea.select();
+      textarea.setSelectionRange(0, text.length);
+      document.execCommand("copy");
+      textarea.remove();
+    }
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }, [text]);
@@ -35,7 +51,7 @@ const CopyButton = ({ text }: { text: string }) => {
       variant="ghost"
       size="icon"
       onClick={handleCopy}
-      className="absolute top-2 right-2 bg-muted opacity-0 group-hover:opacity-100 transition-opacity"
+      className="absolute top-2 right-2 bg-muted opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
       title={copied ? "Copied!" : "Copy"}
     >
       {copied ? <Check size={16} /> : <Clipboard size={16} />}

--- a/src/client/components/quick-open.tsx
+++ b/src/client/components/quick-open.tsx
@@ -173,7 +173,7 @@ export const QuickOpen = ({
     >
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- dialog container */}
       <div
-        className="w-[600px] h-fit max-h-[50vh] flex flex-col bg-popover border border-border rounded-md shadow-2xl overflow-hidden"
+        className="w-[calc(100vw-2rem)] max-w-[600px] h-fit max-h-[50vh] flex flex-col bg-popover border border-border rounded-md shadow-2xl overflow-hidden"
         onClick={handleDialogClick}
         onKeyDown={noop}
       >

--- a/src/client/hooks/use-is-mobile.ts
+++ b/src/client/hooks/use-is-mobile.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_QUERY = "(max-width: 767px)";
+
+export const useIsMobile = (): boolean => {
+  const [isMobile, setIsMobile] = useState(
+    () => window.matchMedia(MOBILE_QUERY).matches
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const onChange = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches);
+    };
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return isMobile;
+};

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -8,7 +8,9 @@ import { program } from "commander";
 import { Hono } from "hono";
 
 import { createApiRouter } from "./api";
+import { getLocalIpAddress } from "./network";
 import { openInBrowser } from "./open-browser";
+import { displayQrCode } from "./qr-display";
 
 const currentDir = import.meta.dirname;
 
@@ -76,16 +78,23 @@ const createApp = (
   return app;
 };
 
+export const getNetworkConfig = (options: { host: boolean }) => ({
+  enableNetwork: options.host,
+  hostname: options.host ? "0.0.0.0" : "127.0.0.1",
+});
+
 program
   .name("specv")
   .description("Local Markdown preview with GitHub-style rendering")
   .version("0.2.0")
   .option("-p, --port <number>", "Port number", "4649")
+  .option("--host", "Expose to local network (enables QR code)")
   .option("--no-auto-close", "Disable auto-close on client disconnect")
   .action((options) => {
     const baseDir = process.cwd();
     const startPort = Number.parseInt(options.port, 10);
     const clientDir = path.join(currentDir, "../client");
+    const networkConfig = getNetworkConfig({ host: !!options.host });
     const app = createApp(
       baseDir,
       clientDir,
@@ -99,17 +108,39 @@ program
 
     const tryListen = (port: number): void => {
       const server = serve(
-        { fetch: app.fetch, hostname: "127.0.0.1", port },
+        { fetch: app.fetch, hostname: networkConfig.hostname, port },
         async (info) => {
-          const url = `http://localhost:${info.port}`;
-          console.log(`specv running at ${url}`);
-          console.log(`Serving: ${baseDir}`);
-          console.log("Press Ctrl+C to stop");
+          const localUrl = `http://localhost:${info.port}`;
+          console.log("");
+          console.log(`  specv v${program.version()}`);
+          console.log("");
+          console.log(`  ➜  Local:   ${localUrl}`);
+
+          const ip = networkConfig.enableNetwork ? getLocalIpAddress() : null;
+          const networkUrl = ip ? `http://${ip}:${info.port}` : null;
+
+          if (networkUrl) {
+            console.log(`  ➜  Network: ${networkUrl}`);
+          } else if (!networkConfig.enableNetwork) {
+            console.log("  ➜  Network: use --host to expose to local network");
+          }
+
+          console.log("");
+          console.log(`  Serving: ${baseDir}`);
+
+          // dev:host 時は Vite プラグイン側で QR を表示するためスキップ
+          if (networkUrl && !process.env.SPECV_HOST) {
+            console.log("");
+            displayQrCode(networkUrl);
+          }
+
+          console.log("");
+          console.log("  Press Ctrl+C to stop");
 
           try {
-            await openInBrowser(url);
+            await openInBrowser(localUrl);
           } catch {
-            console.log(`Open ${url} in your browser`);
+            console.log(`  Open ${localUrl} in your browser`);
           }
         }
       );

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -1,0 +1,16 @@
+import os from "node:os";
+
+export const getLocalIpAddress = (): string | null => {
+  const interfaces = os.networkInterfaces();
+  for (const addrs of Object.values(interfaces)) {
+    if (!addrs) {
+      continue;
+    }
+    for (const addr of addrs) {
+      if (addr.family === "IPv4" && !addr.internal) {
+        return addr.address;
+      }
+    }
+  }
+  return null;
+};

--- a/src/server/qr-display.ts
+++ b/src/server/qr-display.ts
@@ -1,0 +1,7 @@
+import qrcode from "qrcode-terminal";
+
+export const displayQrCode = (url: string): void => {
+  qrcode.generate(url, { small: true }, (code: string) => {
+    console.log(code);
+  });
+};

--- a/tests/cli-network.test.ts
+++ b/tests/cli-network.test.ts
@@ -1,0 +1,15 @@
+import { getNetworkConfig } from "@server/cli";
+
+describe("getNetworkConfig", () => {
+  it("--host なし → localhost バインド、ネットワーク情報なし", () => {
+    const config = getNetworkConfig({ host: false });
+    expect(config.hostname).toBe("127.0.0.1");
+    expect(config.enableNetwork).toBe(false);
+  });
+
+  it("--host あり → 0.0.0.0 バインド、ネットワーク有効", () => {
+    const config = getNetworkConfig({ host: true });
+    expect(config.hostname).toBe("0.0.0.0");
+    expect(config.enableNetwork).toBe(true);
+  });
+});

--- a/tests/components/app-header.test.tsx
+++ b/tests/components/app-header.test.tsx
@@ -30,6 +30,13 @@ vi.mock(import("@tanstack/react-hotkeys"), () => ({
   useHotkey: vi.fn(),
 }));
 
+// matchMedia モック（useIsMobile 用）
+window.matchMedia = vi.fn().mockReturnValue({
+  addEventListener: vi.fn(),
+  matches: false,
+  removeEventListener: vi.fn(),
+}) as typeof window.matchMedia;
+
 describe("app ヘッダー", () => {
   // eslint-disable-next-line jest/no-hooks -- jsdom cleanup required
   afterEach(() => {

--- a/tests/components/app-responsive.test.tsx
+++ b/tests/components/app-responsive.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import { App } from "@/app";
+
+// API モック
+vi.mock(import("@/api"), () => ({
+  fetchFile: vi.fn().mockResolvedValue("# Test"),
+  fetchFiles: vi.fn().mockResolvedValue([
+    { name: "test.md", path: "test.md" },
+    { name: "other.md", path: "other.md" },
+  ]),
+}));
+
+// テーマモック
+vi.mock(import("@/hooks/use-theme"), () => ({
+  useTheme: () => ({ theme: "light" as const, toggle: vi.fn() }),
+}));
+
+// EventSource モック
+class EventSourceMock {
+  // eslint-disable-next-line class-methods-use-this, no-empty-function
+  addEventListener() {}
+  // eslint-disable-next-line class-methods-use-this, no-empty-function
+  close() {}
+  // eslint-disable-next-line class-methods-use-this, no-empty-function
+  removeEventListener() {}
+}
+global.EventSource = EventSourceMock as unknown as typeof EventSource;
+
+// useHotkey モック
+vi.mock(import("@tanstack/react-hotkeys"), () => ({
+  useHotkey: vi.fn(),
+}));
+
+function setMobile(mobile: boolean) {
+  window.matchMedia = vi.fn().mockReturnValue({
+    addEventListener: vi.fn(),
+    matches: mobile,
+    removeEventListener: vi.fn(),
+  }) as typeof window.matchMedia;
+}
+
+describe("app レスポンシブ", () => {
+  // eslint-disable-next-line jest/no-hooks -- jsdom cleanup required
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe("モバイル時", () => {
+    beforeEach(() => {
+      setMobile(true);
+    });
+
+    it("サイドバーが初期状態で非表示", () => {
+      render(<App />);
+      // サイドバーの h1 "specv" が表示されない
+      expect(screen.queryByText("specv")).toBeNull();
+      // Show sidebar ボタンが表示される
+      expect(screen.getByTitle(/Show sidebar/i)).toBeDefined();
+    });
+
+    it("サイドバーを開くとオーバーレイドロワーとして表示される", () => {
+      render(<App />);
+      const toggleButton = screen.getByTitle(/Show sidebar/i);
+      fireEvent.click(toggleButton);
+
+      // サイドバーが表示される
+      expect(screen.getByText("specv")).toBeDefined();
+
+      // バックドロップが存在する
+      const backdrop = document.querySelector(
+        "[data-testid='sidebar-backdrop']"
+      );
+      expect(backdrop).not.toBeNull();
+    });
+
+    it("バックドロップクリックでサイドバーが閉じる", () => {
+      render(<App />);
+      // サイドバーを開く
+      fireEvent.click(screen.getByTitle(/Show sidebar/i));
+      expect(screen.getByText("specv")).toBeDefined();
+
+      // バックドロップをクリック
+      const backdrop = document.querySelector(
+        "[data-testid='sidebar-backdrop']"
+      );
+      fireEvent.click(backdrop!);
+
+      // サイドバーが閉じる
+      expect(screen.queryByText("specv")).toBeNull();
+    });
+
+    it("ファイル選択でサイドバーが閉じる", async () => {
+      render(<App />);
+      // ファイルツリーのロードを待つ
+      await waitFor(() => {
+        expect(screen.getByText("test.md")).toBeDefined();
+      });
+      // サイドバーを開く
+      fireEvent.click(screen.getByTitle(/Show sidebar/i));
+      expect(screen.getByText("specv")).toBeDefined();
+
+      // ファイルを選択
+      const fileItem = screen.getByText("other.md");
+      fireEvent.click(fileItem);
+
+      // サイドバーが閉じる
+      expect(screen.queryByText("specv")).toBeNull();
+    });
+
+    it("リサイズセパレーターが非表示", () => {
+      render(<App />);
+      // サイドバーを開く
+      fireEvent.click(screen.getByTitle(/Show sidebar/i));
+
+      // separator が表示されない
+      expect(screen.queryByRole("separator")).toBeNull();
+    });
+  });
+
+  describe("デスクトップ時", () => {
+    beforeEach(() => {
+      setMobile(false);
+    });
+
+    it("サイドバーが初期状態で表示される", () => {
+      render(<App />);
+      expect(screen.getByText("specv")).toBeDefined();
+      expect(screen.getByTitle(/Hide sidebar/i)).toBeDefined();
+    });
+
+    it("リサイズセパレーターが表示される", () => {
+      render(<App />);
+      expect(screen.getByRole("separator")).toBeDefined();
+    });
+  });
+});

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -1,0 +1,69 @@
+import os from "node:os";
+
+import { getLocalIpAddress } from "@server/network";
+
+vi.mock("node:os");
+
+describe("getLocalIpAddress", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("非内部 IPv4 アドレスを返す", () => {
+    vi.mocked(os.networkInterfaces).mockReturnValue({
+      en0: [
+        {
+          address: "fe80::1",
+          cidr: "fe80::1/64",
+          family: "IPv6",
+          internal: false,
+          mac: "00:00:00:00:00:00",
+          netmask: "ffff:ffff:ffff:ffff::",
+        },
+        {
+          address: "192.168.1.10",
+          cidr: "192.168.1.10/24",
+          family: "IPv4",
+          internal: false,
+          mac: "00:00:00:00:00:00",
+          netmask: "255.255.255.0",
+        },
+      ],
+      lo0: [
+        {
+          address: "127.0.0.1",
+          cidr: "127.0.0.1/8",
+          family: "IPv4",
+          internal: true,
+          mac: "00:00:00:00:00:00",
+          netmask: "255.0.0.0",
+        },
+      ],
+    });
+
+    expect(getLocalIpAddress()).toBe("192.168.1.10");
+  });
+
+  it("該当アドレスがない場合 null を返す", () => {
+    vi.mocked(os.networkInterfaces).mockReturnValue({
+      lo0: [
+        {
+          address: "127.0.0.1",
+          cidr: "127.0.0.1/8",
+          family: "IPv4",
+          internal: true,
+          mac: "00:00:00:00:00:00",
+          netmask: "255.0.0.0",
+        },
+      ],
+    });
+
+    expect(getLocalIpAddress()).toBeNull();
+  });
+
+  it("networkInterfaces が空オブジェクトを返す場合 null を返す", () => {
+    vi.mocked(os.networkInterfaces).mockReturnValue({});
+
+    expect(getLocalIpAddress()).toBeNull();
+  });
+});

--- a/tests/qr-display.test.ts
+++ b/tests/qr-display.test.ts
@@ -1,0 +1,21 @@
+import { displayQrCode } from "@server/qr-display";
+import qrcode from "qrcode-terminal";
+
+vi.mock("qrcode-terminal");
+
+describe("displayQrCode", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("qrcode-terminal.generate を正しい URL と small オプションで呼び出す", () => {
+    const generateSpy = vi.mocked(qrcode.generate);
+    displayQrCode("http://192.168.1.5:4649");
+
+    expect(generateSpy).toHaveBeenCalledWith(
+      "http://192.168.1.5:4649",
+      { small: true },
+      expect.any(Function)
+    );
+  });
+});

--- a/tests/use-is-mobile.test.ts
+++ b/tests/use-is-mobile.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+
+import { useIsMobile } from "@/hooks/use-is-mobile";
+
+function createMockMatchMedia(matches: boolean) {
+  const listeners: Array<(e: { matches: boolean }) => void> = [];
+  const mql = {
+    addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+      listeners.push(cb);
+    },
+    matches,
+    removeEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+      const idx = listeners.indexOf(cb);
+      if (idx >= 0) listeners.splice(idx, 1);
+    },
+  };
+  window.matchMedia = vi.fn().mockReturnValue(mql) as typeof window.matchMedia;
+  return {
+    mql,
+    trigger: (newMatches: boolean) => {
+      mql.matches = newMatches;
+      for (const cb of listeners) cb({ matches: newMatches });
+    },
+  };
+}
+
+describe("hook: useIsMobile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("デスクトップ幅 → false を返す", () => {
+    createMockMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it("モバイル幅 → true を返す", () => {
+    createMockMatchMedia(true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it("リサイズでリアクティブに更新される", () => {
+    const { trigger } = createMockMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      trigger(true);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      trigger(false);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("アンマウント時にリスナーが解除される", () => {
+    const { mql } = createMockMatchMedia(false);
+    const removeSpy = vi.spyOn(mql, "removeEventListener");
+    const { unmount } = renderHook(() => useIsMobile());
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith("change", expect.any(Function));
+  });
+});

--- a/vite-plugin-qrcode.ts
+++ b/vite-plugin-qrcode.ts
@@ -1,0 +1,34 @@
+import type { Plugin } from "vite";
+
+import { getLocalIpAddress } from "./src/server/network";
+import { displayQrCode } from "./src/server/qr-display";
+
+export const qrcodePlugin = (): Plugin => ({
+  apply: "serve",
+  configureServer(server) {
+    if (!process.env.SPECV_HOST) {
+      return;
+    }
+
+    server.httpServer?.once("listening", () => {
+      const ip = getLocalIpAddress();
+      if (!ip) {
+        return;
+      }
+
+      const address = server.httpServer?.address();
+      if (!address || typeof address === "string") {
+        return;
+      }
+
+      const networkUrl = `http://${ip}:${address.port}`;
+
+      // Vite の出力の後に表示されるよう少し遅延
+      setTimeout(() => {
+        console.log("");
+        displayQrCode(networkUrl);
+      }, 100);
+    });
+  },
+  name: "vite-plugin-qrcode",
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,13 +5,15 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+import { qrcodePlugin } from "./vite-plugin-qrcode";
+
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   build: {
     outDir: "dist/client",
   },
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), qrcodePlugin()],
   resolve: {
     alias: {
       "@": path.resolve(currentDir, "./src/client"),
@@ -20,6 +22,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: !!process.env.SPECV_HOST,
     proxy: {
       "/api": "http://localhost:4649",
     },


### PR DESCRIPTION
## Summary

- レスポンシブデザイン対応（モバイルドロワー、バックドロップ、パディング調整、Quick Open 対応）
- `--host` フラグでネットワーク公開 + QR コード表示（本番）
- `dev:host` スクリプトで開発時のスマホ確認を簡易化（Vite プラグイン経由）
- コピーボタンの HTTP 環境フォールバック対応（`execCommand` によるクリップボード操作）

## 主な変更

### Phase 1: レスポンシブデザイン (#47)
- `useIsMobile` フック（`matchMedia` によるブレークポイント判定）
- モバイル時サイドバーをオーバーレイドロワー化（`fixed z-40`）+ バックドロップ
- ファイル選択・バックドロップクリックでサイドバー自動閉じ
- Quick Open を `w-[calc(100vw-2rem)] max-w-[600px]` に
- コンテンツパディング `px-4 py-4 md:px-8 md:py-8`
- サイドバーに specv アイコン + モバイル用閉じるボタン
- コピーボタンをモバイルで常時表示 + clipboard API フォールバック

### Phase 2: QR コード表示 (#42)
- `getLocalIpAddress()` で LAN IP 検出
- `displayQrCode()` で QR コード出力
- `--host` フラグによるオプトイン方式のネットワーク公開
- Vite プラグイン（`vite-plugin-qrcode.ts`）で dev 時の QR 表示
- `dev:host` スクリプト追加

## Test plan

- [x] `nr test` — 24 ファイル、161 テスト全パス
- [x] `nr typecheck` — 型エラーなし
- [x] `nr check` — lint パス
- [ ] `nr build && nr test:e2e` — E2E テスト（レスポンシブ含む）
- [ ] `nr dev:host` → スマホで QR スキャン → レスポンシブ UI 確認
- [ ] `npx specv --host` → QR コード表示確認

Closes #47
Closes #42