### PR TITLE
feat: YAML frontmatter を GitHub 風テーブルで表示 (#59)

### DIFF
--- a/e2e/fixtures/docs/frontmatter.md
+++ b/e2e/fixtures/docs/frontmatter.md
@@ -1,0 +1,9 @@
+---
+title: Frontmatter Test
+date: 2024-01-01
+tags: [test, markdown]
+---
+
+# Frontmatter Test
+
+This document has YAML frontmatter.

--- a/e2e/frontmatter.test.ts
+++ b/e2e/frontmatter.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+
+test("frontmatter 付きファイルのプレビューにテーブルが表示される", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByText("frontmatter.md").click();
+
+  const table = page.locator("table").first();
+  await expect(table).toBeVisible();
+  await expect(table.locator("th", { hasText: "Key" })).toBeVisible();
+  await expect(table.locator("th", { hasText: "Value" })).toBeVisible();
+  await expect(table.locator("td", { hasText: "title" })).toBeVisible();
+  await expect(
+    table.locator("td", { hasText: "Frontmatter Test" })
+  ).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "remark-emoji": "^5.0.2",
     "remark-frontmatter": "^5.0.0",
     "remark-github-blockquote-alert": "^2.0.1",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@base-ui/react": "^1.2.0",
@@ -67,6 +68,7 @@
     "@tanstack/react-hotkeys": "^0.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/jsdom": "^28.0.0",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^25.4.0",
     "@types/qrcode-terminal": "^0.12.2",
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
     devDependencies:
       '@base-ui/react':
         specifier: ^1.2.0
@@ -78,6 +81,9 @@ importers:
       '@types/jsdom':
         specifier: ^28.0.0
         version: 28.0.0
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^25.4.0
         version: 25.4.0

--- a/src/client/lib/markdown-plugins.ts
+++ b/src/client/lib/markdown-plugins.ts
@@ -10,6 +10,8 @@ import { remarkAlert } from "remark-github-blockquote-alert";
 import remarkMath from "remark-math";
 import type { PluggableList } from "unified";
 
+import { remarkFrontmatterTable } from "@/lib/remark-frontmatter-table";
+
 const SANITIZE_SCHEMA = {
   ...defaultSchema,
   attributes: {
@@ -50,6 +52,7 @@ export const REMARK_PLUGINS: PluggableList = [
   remarkAlert,
   remarkEmoji,
   remarkFrontmatter,
+  remarkFrontmatterTable,
   remarkGfm,
   remarkMath,
 ];

--- a/src/client/lib/remark-frontmatter-table.ts
+++ b/src/client/lib/remark-frontmatter-table.ts
@@ -1,0 +1,69 @@
+import type { Root, Table, TableCell, TableRow, Text } from "mdast";
+import type { Plugin } from "unified";
+import { parse } from "yaml";
+
+const text = (value: string): Text => ({
+  type: "text",
+  value,
+});
+
+const cell = (value: string): TableCell => ({
+  children: [text(value)],
+  type: "tableCell",
+});
+
+const row = (cells: TableCell[]): TableRow => ({
+  children: cells,
+  type: "tableRow",
+});
+
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+};
+
+export const remarkFrontmatterTable: Plugin<[], Root> = () => (tree) => {
+  const [firstNode] = tree.children;
+  if (!firstNode || firstNode.type !== "yaml") {
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parse(firstNode.value);
+  } catch {
+    // invalid YAML
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    tree.children.splice(0, 1);
+    return;
+  }
+
+  const entries = Object.entries(parsed as Record<string, unknown>);
+  if (entries.length === 0) {
+    tree.children.splice(0, 1);
+    return;
+  }
+
+  const headerRow = row([cell("Key"), cell("Value")]);
+  const dataRows = entries.map(([key, val]) =>
+    row([cell(key), cell(formatValue(val))])
+  );
+
+  const table: Table = {
+    align: [null, null],
+    children: [headerRow, ...dataRows],
+    type: "table",
+  };
+
+  tree.children[0] = table;
+};

--- a/tests/remark-frontmatter-table.test.ts
+++ b/tests/remark-frontmatter-table.test.ts
@@ -1,0 +1,75 @@
+import rehypeStringify from "rehype-stringify";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+
+import { remarkFrontmatterTable } from "@/lib/remark-frontmatter-table";
+
+const renderMarkdown = async (input: string): Promise<string> => {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkFrontmatter)
+    .use(remarkFrontmatterTable)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeStringify)
+    .process(input);
+  return String(file);
+};
+
+describe("remarkFrontmatterTable", () => {
+  it("frontmatter がテーブルとして出力される", async () => {
+    const html = await renderMarkdown("---\ntitle: Hello\n---\n");
+    expect(html).toContain("<table>");
+  });
+
+  it("テーブルに Key と Value のヘッダーが含まれる", async () => {
+    const html = await renderMarkdown("---\ntitle: Hello\n---\n");
+    expect(html).toContain("<th>Key</th>");
+    expect(html).toContain("<th>Value</th>");
+  });
+
+  it("複数キーが全てテーブルに表示される", async () => {
+    const html = await renderMarkdown(
+      "---\ntitle: Hello\ndate: 2024-01-01\n---\n"
+    );
+    expect(html).toContain("<td>title</td>");
+    expect(html).toContain("<td>Hello</td>");
+    expect(html).toContain("<td>date</td>");
+    expect(html).toContain("<td>2024-01-01</td>");
+  });
+
+  it("配列値がカンマ区切りで表示される", async () => {
+    const html = await renderMarkdown("---\ntags: [test, markdown]\n---\n");
+    expect(html).toContain("<td>test, markdown</td>");
+  });
+
+  it("オブジェクト値が JSON 文字列化で表示される", async () => {
+    const html = await renderMarkdown("---\nmeta:\n  key: value\n---\n");
+    expect(html).toContain("<td>{");
+    expect(html).toContain("key");
+  });
+
+  it("null 値が空文字列で表示される", async () => {
+    const html = await renderMarkdown("---\ndraft:\n---\n");
+    expect(html).toContain("<td>draft</td>");
+    expect(html).toContain("<td></td>");
+  });
+
+  it("frontmatter なしの場合テーブルが出力されない", async () => {
+    const html = await renderMarkdown("# Hello\n\nWorld");
+    expect(html).not.toContain("<table>");
+  });
+
+  it("空の frontmatter ではテーブルを生成しない", async () => {
+    const html = await renderMarkdown("---\n---\n");
+    expect(html).not.toContain("<table>");
+  });
+
+  it("不正な YAML ではテーブルを出さない", async () => {
+    const html = await renderMarkdown("---\n: invalid: yaml: [[\n---\n");
+    expect(html).not.toContain("<table>");
+  });
+});


### PR DESCRIPTION
## 概要
YAML frontmatter を GitHub と同様に Key/Value のテーブルとして表示する機能を追加。
Closes #59

## 設計判断
- カスタム remark プラグインで mdast の `yaml` ノードを `table` ノードに変換するアプローチを採用（rehype レベルでの変換と比較して、既存の GFM テーブルパイプラインを再利用でき、sanitize も自動適用される）
- `tree.children[0]` の直接チェックで `unist-util-visit` による全ツリー走査を回避（frontmatter は常に先頭ノードのため）
- `yaml` パッケージで YAML 値を解釈（`remark-frontmatter` は AST ノード生成のみで値の解釈は行わないため）

## 変更内容
- `remarkFrontmatterTable` プラグインを新規作成（配列→カンマ区切り、オブジェクト→JSON、null→空文字列）
- `REMARK_PLUGINS` に `remarkFrontmatter` 直後で登録
- ユニットテスト 9 ケース、E2E テスト 1 ケースを追加

## テスト計画
- [ ] `nr dev` → frontmatter 付き `.md` ファイルを開き、ページ上部に Key/Value テーブルが表示されることを確認
- [ ] frontmatter なしの `.md` ファイルにテーブルが表示されないことを確認