### PR TITLE
fix: Source 表示にコピーボタンを追加しスクロール追従に対応

### DIFF
--- a/src/client/components/markdown-pre.tsx
+++ b/src/client/components/markdown-pre.tsx
@@ -26,9 +26,15 @@ export const MarkdownPre = ({
       : "";
 
   return (
-    <div className="group relative">
-      <CopyButton text={code} />
-      <pre {...props}>{children}</pre>
+    <div className="not-prose group rounded-md border border-border bg-code-bg">
+      <div className="sticky top-0 z-10 h-0 pointer-events-none">
+        <div className="relative pointer-events-auto">
+          <CopyButton text={code} />
+        </div>
+      </div>
+      <pre className="p-4 text-foreground overflow-x-auto" {...props}>
+        {children}
+      </pre>
     </div>
   );
 };

--- a/src/client/components/source.tsx
+++ b/src/client/components/source.tsx
@@ -1,5 +1,6 @@
 import { Highlight } from "prism-react-renderer";
 
+import { CopyButton } from "@/components/copy-button";
 import { usePrismTheme } from "@/hooks/use-prism-theme";
 import { cn } from "@/lib/utils";
 
@@ -11,29 +12,36 @@ export const Source = ({ content }: SourceProps) => {
   const prismTheme = usePrismTheme();
 
   return (
-    <Highlight theme={prismTheme} code={content} language="markdown">
-      {({ className, tokens, getLineProps, getTokenProps }) => (
-        <pre
-          className={cn(
-            className,
-            "p-4 rounded-lg overflow-x-auto text-sm border border-border bg-code-bg text-foreground"
-          )}
-        >
-          {tokens.map((line, i) => (
-            <div key={`line-${String(i)}`} {...getLineProps({ line })}>
-              <span className="inline-block w-8 text-right mr-4 text-muted-foreground select-none">
-                {i + 1}
-              </span>
-              {line.map((token, j) => (
-                <span
-                  key={`token-${String(j)}`}
-                  {...getTokenProps({ token })}
-                />
-              ))}
-            </div>
-          ))}
-        </pre>
-      )}
-    </Highlight>
+    <div className="group rounded-lg border border-border bg-code-bg">
+      <div className="sticky top-0 z-10 h-0 pointer-events-none">
+        <div className="relative pointer-events-auto">
+          <CopyButton text={content} />
+        </div>
+      </div>
+      <Highlight theme={prismTheme} code={content} language="markdown">
+        {({ className, tokens, getLineProps, getTokenProps }) => (
+          <pre
+            className={cn(
+              className,
+              "p-4 overflow-x-auto text-sm text-foreground"
+            )}
+          >
+            {tokens.map((line, i) => (
+              <div key={`line-${String(i)}`} {...getLineProps({ line })}>
+                <span className="inline-block w-8 text-right mr-4 text-muted-foreground select-none">
+                  {i + 1}
+                </span>
+                {line.map((token, j) => (
+                  <span
+                    key={`token-${String(j)}`}
+                    {...getTokenProps({ token })}
+                  />
+                ))}
+              </div>
+            ))}
+          </pre>
+        )}
+      </Highlight>
+    </div>
   );
 };

--- a/tests/components/source.test.tsx
+++ b/tests/components/source.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { Source } from "@/components/source";
+
+vi.mock(import("@/hooks/use-theme"), () => ({
+  useTheme: () => ({ theme: "light" as const, toggle: vi.fn() }),
+}));
+
+describe("Source", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("コピーボタンが表示される", () => {
+    render(<Source content="# Hello" />);
+
+    expect(screen.getByTitle("Copy")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## 概要

Source 表示とコードブロックのコピーボタンがスクロール時に追従するよう修正。

Fixes #74

## バグ詳細
- **症状**: Source 表示にコピーボタンがない。また、コ��ドブロックのコピーボタンがスクロール時に上部に固定され、長いコードブロックでは見えなくなる
- **再現条件**: 長い Markdown ファイルを Source 表示で閲覧、または長いコードブロ���クを含むファイルを Preview 表示で閲覧
- **再現方法**: 長いファイルを開き、下方向にスクロールするとコピーボタンが見えなくなる

## 原因

CopyButton が `position: absolute` で配置されていた���め、ページスクロール時にコードブロックの上部に固定されたまま画面外に出てしまう。また Source コンポーネントには CopyButton 自体が実装されていなかった。

## 修��内容
- `source.tsx`: CopyButton を追加し、sticky ラッパーパターンでスクロール追従
- `markdown-pre.tsx`: 同様に sticky ラッパーパターンに変更、`not-prose` で視覚コンテナを wrapper に移動
- 視覚スタイル（border/bg）を `<pre>` から外側 wrapper に移動し、ボタンのはみ出しを防止

## 影響範囲
- Source 表示（`source.tsx`）
- Preview 内のコードブロック（`markdown-pre.tsx`）
- CopyButton 自体は変更なし

## テスト計画
- [x] `nr test` — 全ユニットテスト通過（169 passed）
- [x] `nr check` — lint/format/type check 通過
- [x] `source.test.tsx` — コピーボタン表示の新規テスト追加・通過
- [ ] ブラウザ確認: Source 表示でスクロール時にコピーボタンが追従する
- [ ] ブラウザ確認: Preview 内コードブロックでスクロール時にコピーボタンが追従する