### PR TITLE
chore: Nix flake で開発環境を定義し CI/CD を Nix ベースに移行

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,32 +12,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: DeterminateSystems/nix-installer-action@v22
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - run: nix develop --command pnpm install --frozen-lockfile
 
       - name: Lint + Format + Type Check
-        run: pnpm check
+        run: nix develop --command pnpm check
 
       - name: Knip
-        run: pnpm knip
+        run: nix develop --command pnpm knip
 
       - name: Test
-        run: pnpm test
+        run: nix develop --command pnpm test
 
       - name: Build
-        run: pnpm build
+        run: nix develop --command pnpm build
 
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps chromium
+        run: nix develop --command pnpm exec playwright install --with-deps chromium
 
       - name: E2E Tests
-        run: pnpm test:e2e
+        run: nix develop --command pnpm test:e2e
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,27 +13,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: DeterminateSystems/nix-installer-action@v22
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-          registry-url: https://registry.npmjs.org
-
-      - name: Update npm
-        run: npm install -g npm@latest
-
-      - run: pnpm install --frozen-lockfile
+      - run: nix develop --command pnpm install --frozen-lockfile
 
       - name: Lint + Format + Type Check
-        run: pnpm check
+        run: nix develop --command pnpm check
 
       - name: Test
-        run: pnpm test
+        run: nix develop --command pnpm test
 
       - name: Build
-        run: pnpm build
+        run: nix develop --command pnpm build
 
       - name: Publish
-        run: npm publish --provenance --access public
+        run: nix develop --command npm publish --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ dist/
 # Playwright
 test-results/
 playwright-report/
+
+# Nix / direnv
+.direnv/
+.envrc.local

--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ pnpm test
 pnpm build
 ```
 
+### Nix users
+
+If you have Nix (with flakes) and direnv set up, Node.js 24 / pnpm / lefthook
+will be provisioned automatically on `cd` into this repository:
+
+```bash
+direnv allow   # first time only
+```
+
+Without direnv:
+
+```bash
+nix develop
+```
+
 ## CI/CD
 
 Automated via GitHub Actions:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "specv — local Markdown preview dev environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            nodejs_24
+            pnpm
+            lefthook
+            git
+          ];
+
+          shellHook = ''
+            if [ -d .git ]; then
+              ${pkgs.lefthook}/bin/lefthook install --force > /dev/null
+            fi
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## 概要

Nix flake で specv の開発環境を宣言的に定義し、CI/CD も Nix ベースに移行する。
Node.js / pnpm / lefthook のバージョンを一箇所で管理し、ローカル開発と CI の環境不整合を解消する。

## 設計判断

- **Node 24 に統一** — 元の ci.yml は Node 22、publish.yml は Node 24 と不整合があった。publish.yml が 24 だったのは OIDC Trusted Publishing に npm 11.5.1+ が必要なため。nixpkgs の `nodejs_24` 同梱 npm は 11.9.0 でこれを満たすので、両方を 24 に統一。
- **nixpkgs の pnpm を採用** — `pkgs.pnpm` は現在 10.32.1 で `package.json` の `packageManager` と完全一致。corepack 経由での固定は不要と判断。
- **publish は `npm publish` を直接呼ぶ** — `pnpm publish` は内部で npm を shell out するが、[pnpm#9812](https://github.com/pnpm/pnpm/issues/9812) で OIDC Trusted Publishing が正しく通らないケースが報告されている。dev/install/build/test は pnpm、publish step のみ `npm publish --provenance` を使うハイブリッド構成に。
- **direnv 連携あり** — `.envrc` で `use flake` を設定し、リポジトリに `cd` するだけで自動的に開発シェルに入れる。
- **CI action は `@v22` に pin** — `DeterminateSystems/nix-installer-action` の最新リリースタグを固定し、既存の他の action（`@v4` 系）とスタイルを揃える。

## 変更内容

- `flake.nix` 新規作成（`nodejs_24` / `pnpm` / `lefthook` / `git` を devShell に提供、`shellHook` で lefthook を自動インストール）
- `flake.lock` 自動生成
- `.envrc` 新規作成（direnv 連携）
- `.gitignore` に `.direnv/` と `.envrc.local` を追加
- `README.md` に「Nix users」節を追加
- `.github/workflows/ci.yml` を `nix develop --command` ベースに書き換え、`setup-node` / `pnpm/action-setup` を削除
- `.github/workflows/publish.yml` も同様に書き換え、`npm install -g npm@latest` を削除（Node 24 同梱 npm が Trusted Publishing 要件を満たすため不要）

## テスト計画

- [x] \`nix develop --command pnpm install --frozen-lockfile\` が通る
- [x] \`nix develop --command pnpm check\` が通る (123 files formatted, 75 lint-clean)
- [x] \`nix develop --command pnpm knip\` が通る
- [x] \`nix develop --command pnpm test\` が通る (168 passed)
- [x] \`nix develop --command pnpm build\` が通る
- [x] \`nix develop --command pnpm test:e2e\` が通る (23 passed)
- [ ] GitHub Actions の CI (ci.yml) が PR 上で成功する
- [ ] 次回リリース時、publish.yml の OIDC Trusted Publishing が動作する
- [ ] \`direnv allow\` で自動的に dev shell に入れる