### PR TITLE
chore: GitHub Sponsors の FUNDING.yml を追加 (#100)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: daiki-beppu


### PR DESCRIPTION
## Summary

- GitHub Sponsors のプロフィールが承認・公開されたため、`.github/FUNDING.yml` を追加してリポジトリ右サイドバーに **Sponsor** ボタンを表示する。

## 変更内容

- 新規ファイル `.github/FUNDING.yml`:
  ```yaml
  github: daiki-beppu
  ```

## Test plan

- [ ] PR マージ後、https://github.com/daiki-beppu/specv の右サイドバーに **Sponsor** ボタンが表示されることを確認

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)