### PR TITLE
test: 既存テストの命名統一と 1 行 1 ケース分割 (#107)

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -11,7 +11,8 @@ const TINY_PNG = Buffer.from(
   "base64"
 );
 
-describe("gET /api/files", () => {
+// eslint-disable-next-line vitest/prefer-lowercase-title -- HTTP method
+describe("GET /api/files", () => {
   it("markdown ファイル一覧を JSON で返す", async () => {
     await withTmpDir(async (tmpDir) => {
       createFile(tmpDir, "README.md", "# Hello");
@@ -57,7 +58,8 @@ describe("gET /api/files", () => {
   });
 });
 
-describe("gET /api/file", () => {
+// eslint-disable-next-line vitest/prefer-lowercase-title -- HTTP method
+describe("GET /api/file", () => {
   it("path パラメータなしで 400 を返す", async () => {
     await withTmpDir(async (tmpDir) => {
       const app = createApiRouter(tmpDir);
@@ -94,7 +96,8 @@ describe("gET /api/file", () => {
   });
 });
 
-describe("gET /api/image", () => {
+// eslint-disable-next-line vitest/prefer-lowercase-title -- HTTP method
+describe("GET /api/image", () => {
   it("path パラメータなしで 400 を返す", async () => {
     await withTmpDir(async (tmpDir) => {
       const app = createApiRouter(tmpDir);

--- a/tests/components/app-header.test.tsx
+++ b/tests/components/app-header.test.tsx
@@ -51,17 +51,20 @@ describe("app ヘッダー", () => {
     cleanup();
   });
 
-  it("サイドバー開閉ボタンをクリックするとサイドバーが切り替わる", () => {
+  it("初期表示でサイドバー開閉ボタンが表示される", () => {
     render(<App />);
 
-    // サイドバーが初期表示されている
     const toggleButton = screen.getByTitle(/sidebar/i);
-    expect(toggleButton).toBeDefined();
 
-    // ⌘B で表示されるサイドバーを隠す
+    expect(toggleButton).toBeDefined();
+  });
+
+  it("サイドバー開閉ボタンをクリックすると Show sidebar 状態に切り替わる", () => {
+    render(<App />);
+    const toggleButton = screen.getByTitle(/sidebar/i);
+
     fireEvent.click(toggleButton);
 
-    // タイトルが "Show sidebar" に変わる
     expect(screen.getByTitle(/Show sidebar/i)).toBeDefined();
   });
 

--- a/tests/components/file-tree.test.tsx
+++ b/tests/components/file-tree.test.tsx
@@ -30,20 +30,24 @@ describe("file-tree", () => {
     expect(screen.getByText("README.md")).toBeDefined();
   });
 
-  it("ディレクトリをクリックすると展開/折畳みが切り替わる", () => {
+  it("ディレクトリをクリックすると折畳まれる", () => {
     render(
       <FileTree files={sampleFiles} selectedPath={null} onSelect={noop} />
     );
 
-    // Docs は computeAutoExpandPaths によりデフォルト展開される
-    expect(screen.getByText("guide.md")).toBeDefined();
-
-    // Docs をクリックして折畳む
     fireEvent.click(screen.getByText("docs"));
+
     expect(screen.queryByText("guide.md")).toBeNull();
+  });
 
-    // 再度クリックして展開
+  it("折畳まれたディレクトリをクリックすると展開する", () => {
+    render(
+      <FileTree files={sampleFiles} selectedPath={null} onSelect={noop} />
+    );
     fireEvent.click(screen.getByText("docs"));
+
+    fireEvent.click(screen.getByText("docs"));
+
     expect(screen.getByText("guide.md")).toBeDefined();
   });
 
@@ -72,7 +76,7 @@ describe("file-tree", () => {
     expect(selected?.textContent).toContain("README.md");
   });
 
-  it("検索欄にテキストを入力するとツリーがフィルタされる", () => {
+  it("検索クエリにマッチしたファイルが表示される", () => {
     render(
       <FileTree files={sampleFiles} selectedPath={null} onSelect={noop} />
     );
@@ -81,6 +85,16 @@ describe("file-tree", () => {
     fireEvent.change(searchInput, { target: { value: "guide" } });
 
     expect(screen.getByText("guide.md")).toBeDefined();
+  });
+
+  it("検索クエリにマッチしないファイルは非表示になる", () => {
+    render(
+      <FileTree files={sampleFiles} selectedPath={null} onSelect={noop} />
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search files...");
+    fireEvent.change(searchInput, { target: { value: "guide" } });
+
     expect(screen.queryByText("README.md")).toBeNull();
   });
 

--- a/tests/components/quick-open.test.tsx
+++ b/tests/components/quick-open.test.tsx
@@ -61,7 +61,7 @@ describe("quick-open", () => {
     expect(screen.queryByPlaceholderText("Go to File")).toBeNull();
   });
 
-  it("テキスト入力でファイルリストがフィルタされる", () => {
+  it("テキスト入力でマッチしたファイルが候補に表示される", () => {
     render(
       <QuickOpen files={sampleFiles} open onClose={noop} onSelect={noop} />
     );
@@ -74,11 +74,23 @@ describe("quick-open", () => {
     const hasIndex = [...items].some((el) =>
       el.textContent?.includes("index.ts")
     );
+
+    expect(hasIndex).toBeTruthy();
+  });
+
+  it("テキスト入力でマッチしないファイルは候補に表示されない", () => {
+    render(
+      <QuickOpen files={sampleFiles} open onClose={noop} onSelect={noop} />
+    );
+
+    const input = screen.getByPlaceholderText("Go to File");
+    fireEvent.change(input, { target: { value: "index" } });
+
+    const items = document.querySelectorAll("[cmdk-item]");
     const hasReadme = [...items].some((el) =>
       el.textContent?.includes("README.md")
     );
 
-    expect(hasIndex).toBeTruthy();
     expect(hasReadme).toBeFalsy();
   });
 

--- a/tests/components/tree.test.tsx
+++ b/tests/components/tree.test.tsx
@@ -64,7 +64,7 @@ describe("tree", () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
-  it("展開中のディレクトリは aria-expanded='true' で子要素が表示される", () => {
+  it("展開中のディレクトリは aria-expanded='true' を持つ", () => {
     render(
       <Tree>
         <TreeItem expanded name="docs" onToggle={noop}>
@@ -74,11 +74,23 @@ describe("tree", () => {
     );
 
     const dir = screen.getByRole("treeitem", { expanded: true });
+
     expect(dir).toBeDefined();
+  });
+
+  it("展開中のディレクトリは子要素を表示する", () => {
+    render(
+      <Tree>
+        <TreeItem expanded name="docs" onToggle={noop}>
+          <TreeLeaf name="guide.md" selected={false} onSelect={noop} />
+        </TreeItem>
+      </Tree>
+    );
+
     expect(screen.getByText("guide.md")).toBeDefined();
   });
 
-  it("折畳み中のディレクトリは aria-expanded='false' で子要素が非表示", () => {
+  it("折畳み中のディレクトリは aria-expanded='false' を持つ", () => {
     render(
       <Tree>
         <TreeItem expanded={false} name="docs" onToggle={noop}>
@@ -88,11 +100,23 @@ describe("tree", () => {
     );
 
     const dir = screen.getByRole("treeitem", { expanded: false });
+
     expect(dir).toBeDefined();
+  });
+
+  it("折畳み中のディレクトリは子要素を表示しない", () => {
+    render(
+      <Tree>
+        <TreeItem expanded={false} name="docs" onToggle={noop}>
+          <TreeLeaf name="guide.md" selected={false} onSelect={noop} />
+        </TreeItem>
+      </Tree>
+    );
+
     expect(screen.queryByText("guide.md")).toBeNull();
   });
 
-  it("選択中のファイルは aria-selected='true' で区別できる", () => {
+  it("選択中のファイルは aria-selected='true' を持つ", () => {
     render(
       <Tree>
         <TreeLeaf name="README.md" selected onSelect={noop} />
@@ -104,11 +128,23 @@ describe("tree", () => {
     const selected = items.find(
       (item) => item.getAttribute("aria-selected") === "true"
     );
+
+    expect(selected).toBeDefined();
+  });
+
+  it("未選択のファイルは aria-selected='false' を持つ", () => {
+    render(
+      <Tree>
+        <TreeLeaf name="README.md" selected onSelect={noop} />
+        <TreeLeaf name="other.md" selected={false} onSelect={noop} />
+      </Tree>
+    );
+
+    const items = screen.getAllByRole("treeitem");
     const unselected = items.find(
       (item) => item.getAttribute("aria-selected") === "false"
     );
 
-    expect(selected).toBeDefined();
     expect(unselected).toBeDefined();
   });
 

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -69,21 +69,27 @@ describe("validatePath function", () => {
 });
 
 describe("validateImagePath function", () => {
-  it("正常な画像パスを許可する (.png, .jpg, .jpeg, .gif, .svg, .webp)", () => {
-    for (const ext of [".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"]) {
-      expect(validateImagePath(`image${ext}`, baseDir)).toBe(
-        path.join(baseDir, `image${ext}`)
-      );
-    }
+  it.each([
+    { ext: ".png" },
+    { ext: ".jpg" },
+    { ext: ".jpeg" },
+    { ext: ".gif" },
+    { ext: ".svg" },
+    { ext: ".webp" },
+  ])("$ext 拡張子の画像パスを許可する", ({ ext }) => {
+    expect(validateImagePath(`image${ext}`, baseDir)).toBe(
+      path.join(baseDir, `image${ext}`)
+    );
   });
 
-  it("非対応拡張子を拒否する", () => {
-    for (const ext of [".exe", ".sh", ".md"]) {
+  it.each([{ ext: ".exe" }, { ext: ".sh" }, { ext: ".md" }])(
+    "$ext を拒否する",
+    ({ ext }) => {
       expect(() => validateImagePath(`file${ext}`, baseDir)).toThrow(
         /Unsupported image format/
       );
     }
-  });
+  );
 
   it("../を含むパストラバーサルを拒否する", () => {
     expect(() => validateImagePath("../etc/image.png", baseDir)).toThrow(


### PR DESCRIPTION
## Summary

親 #89（既存テストの方針整合 [65-B]）のサブタスク #107 の実装 PR。`@.takt/facets/policies/specv-testing.md` 規約に沿って、`tests/` 配下 6 ファイルの命名統一と 1 行 1 ケース分割を実施。プロダクションコード（`src/`）は不変。

## 変更内容

| ファイル | 概要 |
|---------|------|
| `tests/api.test.ts` | `describe("gET /api/...")` × 3 を `GET` に修正、各 describe 直前に `// eslint-disable-next-line vitest/prefer-lowercase-title -- HTTP method` を局所付与 |
| `tests/security.test.ts` | `validateImagePath` の許可 `for-of`（6 拡張子）と拒否 `for-of`（3 拡張子）を `it.each` で 9 ケースに分割 |
| `tests/components/file-tree.test.tsx` | 「展開/折畳切替」「フィルタ」を 1 行 1 ケースに分割（+2 it） |
| `tests/components/tree.test.tsx` | 展開中・折畳み中・選択状態の複合検証を aria 属性確認と DOM 表示確認に分けて 6 it に分割（+3 it） |
| `tests/components/quick-open.test.tsx` | フィルタ複合検証をマッチ存在・非マッチ非表示の 2 it に分割（+1 it） |
| `tests/components/app-header.test.tsx` | サイドバー開閉を初期表示・クリック後遷移の 2 it に分割（+1 it） |

差分規模: 6 ファイル / +103 / -29 行 / +14 it（既存 217 → 231）

## 検証

- [x] `nr test` → 29 test files / 231 passed / 1 skipped / 1 todo
- [x] `nr check` → 140 files formatted / 83 files lint clean
- [x] `nr fix` → 差分ゼロ（`gET` への再小文字化が起きないことを確認）
- [x] `git status` で変更ファイルが指定 6 test ファイルのみ、`src/` 無変更を確認

## タスク完了状況

### 命名統一

- [x] `tests/api.test.ts` L14 / L60 / L97: `describe("gET /api/...")` → `describe("GET /api/...")`（typo 修正、3 箇所）

### 1 行 1 ケース分割

- [x] `tests/security.test.ts` L72-78: `for-of` ループを `it.each` で 6 ケースに分割
- [x] `tests/security.test.ts` L80-86: 非対応拡張子拒否の `for-of` ループを `it.each` で 3 ケースに分割
- [x] `tests/components/file-tree.test.tsx` L33-48: 「展開/折畳み切替」を 2 ケースに分割
- [x] `tests/components/file-tree.test.tsx` L75-85: フィルタを 2 ケースに分割
- [x] `tests/components/tree.test.tsx` L67-79: 展開中検証を 2 ケースに分割
- [x] `tests/components/tree.test.tsx` L81-93: 折畳み中検証を 2 ケースに分割
- [x] `tests/components/tree.test.tsx` L95-113: ファイル選択検証を 2 ケースに分割
- [x] `tests/components/quick-open.test.tsx` L64-83: フィルタ検証を 2 ケースに分割
- [x] `tests/components/app-header.test.tsx` L54-66: サイドバー開閉を 2 ケースに分割

## スコープ外（別サブ issue）

- preview-rendering の Unit/E2E 責務分離（#108）
- copy-button の Preview 統合分離・AAA 整形（#109）
- E2E の固定待ち置換・数式テスト分割（#110）

## 関連

- 親: #89
- 規約 SSOT: `.takt/facets/policies/specv-testing.md`

Closes #107