### PR TITLE
[#127] issue-127-tsconfig-wo-type-awa

### DIFF
--- a/tests/components/copy-button.test.tsx
+++ b/tests/components/copy-button.test.tsx
@@ -19,7 +19,7 @@ describe(CopyButton, () => {
   });
 
   it("クリックで navigator.clipboard.writeText(text) が呼ばれる", async () => {
-    const writeText = vi.fn().mockResolvedValue();
+    const writeText = vi.fn(() => Promise.resolve());
     Object.assign(navigator, { clipboard: { writeText } });
 
     render(<CopyButton text="hello world" />);
@@ -31,7 +31,7 @@ describe(CopyButton, () => {
   });
 
   it("writeText 解決後に title が 'Copied!' になり Check アイコンが表示される", async () => {
-    const writeText = vi.fn().mockResolvedValue();
+    const writeText = vi.fn(() => Promise.resolve());
     Object.assign(navigator, { clipboard: { writeText } });
 
     render(<CopyButton text="hello" />);
@@ -45,7 +45,7 @@ describe(CopyButton, () => {
     vi.useFakeTimers();
     try {
       // Arrange
-      const writeText = vi.fn().mockResolvedValue();
+      const writeText = vi.fn(() => Promise.resolve());
       Object.assign(navigator, { clipboard: { writeText } });
       render(<CopyButton text="hello" />);
 
@@ -73,7 +73,7 @@ describe(CopyButton, () => {
 
   it("初回クリックでは prop の text で writeText が呼ばれる", async () => {
     // Arrange
-    const writeText = vi.fn().mockResolvedValue();
+    const writeText = vi.fn(() => Promise.resolve());
     Object.assign(navigator, { clipboard: { writeText } });
     render(<CopyButton text="first" />);
 
@@ -88,7 +88,7 @@ describe(CopyButton, () => {
 
   it("rerender 後のクリックでは新しい text で writeText が呼ばれる", async () => {
     // Arrange
-    const writeText = vi.fn().mockResolvedValue();
+    const writeText = vi.fn(() => Promise.resolve());
     Object.assign(navigator, { clipboard: { writeText } });
     const { rerender } = render(<CopyButton text="first" />);
     rerender(<CopyButton text="second" />);

--- a/tests/components/mermaid-block.test.tsx
+++ b/tests/components/mermaid-block.test.tsx
@@ -16,6 +16,7 @@ describe("MermaidBlock", () => {
     vi.mocked(mermaid.default.initialize).mockReturnValue();
     vi.mocked(mermaid.default.render).mockResolvedValue({
       bindFunctions: vi.fn(),
+      diagramType: "flowchart",
       svg: '<svg data-testid="mermaid-svg">mock diagram</svg>',
     });
 

--- a/tests/components/quick-open.test.tsx
+++ b/tests/components/quick-open.test.tsx
@@ -174,7 +174,7 @@ describe("quick-open", () => {
     // ↓キーで次のアイテムに移動
     fireEvent.keyDown(input, { key: "ArrowDown" });
 
-    const items = document.querySelectorAll("[cmdk-item]");
+    const items = document.querySelectorAll<HTMLElement>("[cmdk-item]");
     const selected = [...items].find(
       (item) => item.dataset.selected === "true"
     );

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -19,6 +19,7 @@ describe(getLocalIpAddress, () => {
           internal: false,
           mac: "00:00:00:00:00:00",
           netmask: "ffff:ffff:ffff:ffff::",
+          scopeid: 0,
         },
         {
           address: "192.168.1.10",

--- a/tests/open-browser.test.ts
+++ b/tests/open-browser.test.ts
@@ -4,11 +4,11 @@ const { mockExecFile } = vi.hoisted(() => ({
   mockExecFile: vi.fn(),
 }));
 
-vi.mock(import("node:child_process"), () => ({
+vi.mock("node:child_process", () => ({
   execFile: mockExecFile,
 }));
 
-vi.mock(import("node:util"), () => ({
+vi.mock("node:util", () => ({
   promisify: () => mockExecFile,
 }));
 

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -220,10 +220,9 @@ describe("server: createWatcher (mocked fs.watch)", () => {
       const { close } = createWatcher(tmpDir, cb);
 
       try {
-        const captured = watchSpy.mock.calls[0]?.[2] as (
-          event: string,
-          filename: string | null
-        ) => void;
+        const captured = (
+          watchSpy.mock.calls[0] as unknown[] | undefined
+        )?.[2] as (event: string, filename: string | null) => void;
         captured("change", null);
 
         await delay(500);
@@ -241,10 +240,9 @@ describe("server: createWatcher (mocked fs.watch)", () => {
       const { close } = createWatcher(tmpDir, cb);
 
       try {
-        const captured = watchSpy.mock.calls[0]?.[2] as (
-          event: string,
-          filename: string | null
-        ) => void;
+        const captured = (
+          watchSpy.mock.calls[0] as unknown[] | undefined
+        )?.[2] as (event: string, filename: string | null) => void;
         captured("change", "../external.md");
 
         await delay(500);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,14 +8,13 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
-    "baseUrl": ".",
+    "types": ["vitest/globals", "node"],
     "paths": {
       "@/*": ["./src/client/*"],
       "@server/*": ["./src/server/*"],
       "@shared/*": ["./src/shared/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary

## 概要

issue #126（Vite+ の type-aware lint 有効化）の前提として、`tsconfig.json` を type-aware lint が機能する形に整える。

## 親 issue

#126

## 変更内容

- [ ] `tsconfig.json` の `include` に `tests` を追加（type-check が tests/ を対象にするため）
- [ ] `compilerOptions.baseUrl: "."` を削除（oxlint tsgolint が deprecated 警告を出す。`paths` 単独で動作する）
- [ ] `compilerOptions.types` に `["vitest/globals", "node"]` を追加（vitest globals を tsc が認識するため）

## 受け入れ基準

- [ ] `nr check` が引き続き通る
- [ ] `nr test` が引き続き通る
- [ ] `tests/` 配下のファイルが `tsc --noEmit` の対象になっている
- [ ] oxlint の `baseUrl` deprecated 警告が出ない

## メモ

これ単独では type-aware lint は有効化しない。あくまで前提整備のみ。本体の有効化は #126 本体で行う。

## Execution Report

Workflow `default` completed successfully.

Closes #127