### PR TITLE
[#128] issue-128-no-floating-promises

### DIFF
--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -66,7 +66,7 @@ const useLoadFiles = (
         logError("Failed to load files:", error);
       }
     };
-    load();
+    void load();
   }, [setFiles, setSelectedPath]);
 };
 
@@ -86,7 +86,7 @@ const useLoadContent = (
         logError("Failed to load file:", error);
       }
     };
-    load();
+    void load();
   }, [selectedPath, setContent]);
 };
 

--- a/src/client/components/copy-button.tsx
+++ b/src/client/components/copy-button.tsx
@@ -28,11 +28,15 @@ export const CopyButton = ({ text }: { text: string }) => {
     setTimeout(() => setCopied(false), 2000);
   }, [text]);
 
+  const handleClick = useCallback(() => {
+    void handleCopy();
+  }, [handleCopy]);
+
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={handleCopy}
+      onClick={handleClick}
       className="absolute top-2 right-2 bg-muted opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
       title={copied ? "Copied!" : "Copy"}
     >

--- a/src/client/components/mermaid-block.tsx
+++ b/src/client/components/mermaid-block.tsx
@@ -45,7 +45,7 @@ const useMermaidRender = (code: string, theme: string) => {
       }
     };
 
-    renderDiagram();
+    void renderDiagram();
 
     return () => {
       cancelled = true;

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -81,16 +81,18 @@ const setupWatcher = (
       if (treeDebounceTimer) {
         clearTimeout(treeDebounceTimer);
       }
-      treeDebounceTimer = setTimeout(async () => {
-        try {
-          const files = await scanMarkdownFiles(baseDir);
-          broadcast({
-            data: JSON.stringify({ files } satisfies TreeChangedPayload),
-            event: "tree-changed",
-          });
-        } catch {
-          // Scan failure is non-fatal
-        }
+      treeDebounceTimer = setTimeout(() => {
+        void (async () => {
+          try {
+            const files = await scanMarkdownFiles(baseDir);
+            broadcast({
+              data: JSON.stringify({ files } satisfies TreeChangedPayload),
+              event: "tree-changed",
+            });
+          } catch {
+            // Scan failure is non-fatal
+          }
+        })();
       }, TREE_DEBOUNCE_MS);
     }
   });

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import fs from "node:fs";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -115,42 +116,46 @@ program
         : undefined
     );
 
+    const announceAndOpen = async (info: AddressInfo): Promise<void> => {
+      const localUrl = `http://localhost:${info.port}`;
+      console.log("");
+      console.log(`  specv v${program.version()}`);
+      console.log("");
+      console.log(`  ➜  Local:   ${localUrl}`);
+
+      const ip = networkConfig.enableNetwork ? getLocalIpAddress() : null;
+      const networkUrl = ip ? `http://${ip}:${info.port}` : null;
+
+      if (networkUrl) {
+        console.log(`  ➜  Network: ${networkUrl}`);
+      } else if (!networkConfig.enableNetwork) {
+        console.log("  ➜  Network: use --host to expose to local network");
+      }
+
+      console.log("");
+      console.log(`  Serving: ${baseDir}`);
+
+      // Dev:host 時は Vite プラグイン側で QR を表示するためスキップ
+      if (networkUrl && !process.env.SPECV_HOST) {
+        console.log("");
+        displayQrCode(networkUrl);
+      }
+
+      console.log("");
+      console.log("  Press Ctrl+C to stop");
+
+      try {
+        await openInBrowser(localUrl);
+      } catch {
+        console.log(`  Open ${localUrl} in your browser`);
+      }
+    };
+
     const tryListen = (port: number): void => {
       const server = serve(
         { fetch: app.fetch, hostname: networkConfig.hostname, port },
-        async (info) => {
-          const localUrl = `http://localhost:${info.port}`;
-          console.log("");
-          console.log(`  specv v${program.version()}`);
-          console.log("");
-          console.log(`  ➜  Local:   ${localUrl}`);
-
-          const ip = networkConfig.enableNetwork ? getLocalIpAddress() : null;
-          const networkUrl = ip ? `http://${ip}:${info.port}` : null;
-
-          if (networkUrl) {
-            console.log(`  ➜  Network: ${networkUrl}`);
-          } else if (!networkConfig.enableNetwork) {
-            console.log("  ➜  Network: use --host to expose to local network");
-          }
-
-          console.log("");
-          console.log(`  Serving: ${baseDir}`);
-
-          // Dev:host 時は Vite プラグイン側で QR を表示するためスキップ
-          if (networkUrl && !process.env.SPECV_HOST) {
-            console.log("");
-            displayQrCode(networkUrl);
-          }
-
-          console.log("");
-          console.log("  Press Ctrl+C to stop");
-
-          try {
-            await openInBrowser(localUrl);
-          } catch {
-            console.log(`  Open ${localUrl} in your browser`);
-          }
+        (info) => {
+          void announceAndOpen(info);
         }
       );
 

--- a/tests/components/app-error.test.tsx
+++ b/tests/components/app-error.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { fetchFile, fetchFiles } from "@/api";
+import { App } from "@/app";
+import { logError } from "@/lib/logger";
+
+// API モック（per-test に挙動を差し替えるため初期実装は空）
+vi.mock(import("@/api"), () => ({
+  fetchFile: vi.fn(),
+  fetchFiles: vi.fn(),
+}));
+
+// logError を spy 可能にする
+vi.mock(import("@/lib/logger"), () => ({
+  logError: vi.fn(),
+}));
+
+// テーマモック
+vi.mock(import("@/hooks/use-theme"), () => ({
+  useTheme: () => ({ theme: "light" as const, toggle: vi.fn() }),
+}));
+
+// EventSource モック（useWatch / useLifecycle で使われる）
+class EventSourceMock {
+  // eslint-disable-next-line class-methods-use-this, no-empty-function
+  addEventListener() {}
+  // eslint-disable-next-line class-methods-use-this, no-empty-function
+  close() {}
+  // eslint-disable-next-line class-methods-use-this, no-empty-function
+  removeEventListener() {}
+}
+global.EventSource = EventSourceMock as unknown as typeof EventSource;
+
+// UseHotkey モック
+vi.mock(import("@tanstack/react-hotkeys"), () => ({
+  useHotkey: vi.fn(),
+}));
+
+// MatchMedia モック（useIsMobile で必要）
+Object.defineProperty(window, "matchMedia", {
+  configurable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    matches: false,
+    media: query,
+    onchange: null,
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  })),
+  writable: true,
+});
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(App, () => {
+  // eslint-disable-next-line jest/no-hooks -- jsdom cleanup と mock リセットに必要
+  beforeEach(() => {
+    vi.mocked(fetchFile).mockReset();
+    vi.mocked(fetchFiles).mockReset();
+    vi.mocked(logError).mockReset();
+  });
+
+  // eslint-disable-next-line jest/no-hooks -- jsdom cleanup required
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("読み込み失敗時", () => {
+    it("fetchFiles が reject したとき logError が呼ばれツリーは空のまま render が throw しない", async () => {
+      // Arrange
+      vi.mocked(fetchFiles).mockRejectedValueOnce(new Error("fail"));
+      vi.mocked(fetchFile).mockResolvedValue("");
+
+      // Act
+      render(<App />);
+
+      // Assert
+      await waitFor(() => {
+        expect(logError).toHaveBeenCalledWith(
+          "Failed to load files:",
+          expect.any(Error)
+        );
+      });
+      // ファイルツリーは空のまま（fetchFiles が成功していないので test.md は描画されない）
+      expect(screen.queryByText("test.md")).toBeNull();
+    });
+
+    it("fetchFile が reject したとき logError が呼ばれ render が throw しない", async () => {
+      // Arrange
+      vi.mocked(fetchFiles).mockResolvedValue([
+        { name: "test.md", path: "test.md" },
+      ]);
+      vi.mocked(fetchFile).mockRejectedValueOnce(new Error("fail"));
+
+      // Act
+      render(<App />);
+
+      // Assert
+      await waitFor(() => {
+        expect(logError).toHaveBeenCalledWith(
+          "Failed to load file:",
+          expect.any(Error)
+        );
+      });
+    });
+  });
+});

--- a/tests/watch-api.test.ts
+++ b/tests/watch-api.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
 import { createApiRouter } from "@server/api";
@@ -170,6 +172,43 @@ describe("gET /api/watch", () => {
       expect(() =>
         watchers[0].emit({ path: "test.md", type: "change" })
       ).not.toThrow();
+    });
+  });
+
+  it("scanMarkdownFiles が throw したとき tree-changed が SSE に流れず後続の change は届く", async () => {
+    // setupWatcher 内 setTimeout コールバックの try/catch (Scan failure is non-fatal) を担保する。
+    // baseDir を subdir として作成し、watcher 登録後に subdir のみ rm することで scan を恒常失敗させる。
+    // tmpDir 自体は withTmpDir の finally に委ね、ENOENT 衝突を避ける（tests/api.test.ts:42-58 と同型）。
+    await withTmpDir(async (tmpDir) => {
+      const baseDir = path.join(tmpDir, "base");
+      fs.mkdirSync(baseDir);
+      const { app, watchers } = setupWatchApp(baseDir);
+      const body = await requestWatch(app);
+      const reader = body.getReader();
+      const decoder = new TextDecoder();
+
+      fs.rmSync(baseDir, { force: true, recursive: true });
+
+      try {
+        await delay(50);
+        watchers[0].emit({ path: "new.md", type: "add" });
+
+        const firstRead = reader.read();
+        const raceResult = await Promise.race([
+          firstRead.then(() => "got" as const),
+          delay(400).then(() => "timeout" as const),
+        ]);
+
+        expect(raceResult).toBe("timeout");
+
+        watchers[0].emit({ path: "any", type: "change" });
+        const chunk = await firstRead;
+        const text = decoder.decode(chunk.value);
+
+        expect(text).toContain("event: file-changed");
+      } finally {
+        await reader.cancel();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

## 概要

issue #126（Vite+ の type-aware lint 有効化）の段階導入として、Promise の取り扱いに関する type-aware ルール違反を解消する。バグ温床に直結するため最優先で対応する。

## 親 issue

#126

## 対象ルール

| ルール | 想定件数 | 内容 |
|---|---|---|
| `typescript/no-floating-promises` | 3 | `await` し忘れ・`.catch()` 漏れの Promise |
| `typescript/no-misused-promises` | 3 | Promise を boolean 文脈や非 async ハンドラに渡している箇所 |

合計 6 件（PR #125 時点の計測）。

## 進め方

1. ローカルで `lint.options.typeAware: true` / `typeCheck: true` を一時的に有効にして違反箇所を列挙
2. 1 件ずつ修正（`await` 追加 / `void` キャスト / `async` ハンドラへ書き換え）
3. 修正後、type-aware を再度 off に戻す（本 PR では有効化しない。最終 on は #126 本体で実施）

## 受け入れ基準

- [ ] type-aware を有効化しても `typescript/no-floating-promises` と `typescript/no-misused-promises` が 0 件
- [ ] `nr test` / `nr test:e2e` が通る
- [ ] `nr check` が通る

## メモ

- ルール自体は **off にしない**（issue #126 のゴールは「全ルール on のまま typeAware: true」）
- 本 issue ではルール解消のみ。`vite.config.ts` の `lint.options` 変更は #126 本体で行う

## Execution Report

Workflow `default` completed successfully.

Closes #128