### PR TITLE
[#129] issue-129-strict-boolean-expre

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
       use: { browserName: "chromium" },
     },
   ],
-  reporter: process.env.CI ? "github" : "list",
+  reporter:
+    process.env.CI !== undefined && process.env.CI !== "" ? "github" : "list",
   retries: 0,
   testDir: "./e2e",
   timeout: 30_000,
@@ -23,6 +24,6 @@ export default defineConfig({
     command: `node ${cliPath} -p 4650 --no-auto-close`,
     cwd: fixturesDir,
     port: 4650,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: process.env.CI === undefined || process.env.CI === "",
   },
 });

--- a/src/client/components/code-block.tsx
+++ b/src/client/components/code-block.tsx
@@ -12,7 +12,7 @@ export const CodeBlock = ({
   ...props
 }: ComponentPropsWithoutRef<"code">) => {
   const prismTheme = usePrismTheme();
-  const match = /language-(\w+)/.exec(className || "");
+  const match = /language-(\w+)/.exec(className ?? "");
   const code = String(children).replace(/\n$/, "");
 
   if (!match) {

--- a/src/client/components/file-tree.tsx
+++ b/src/client/components/file-tree.tsx
@@ -28,7 +28,7 @@ const filterTree = (nodes: FileNode[], query: string): FileNode[] => {
   const lower = query.toLowerCase();
   const result: FileNode[] = [];
   for (const node of nodes) {
-    if (node.children) {
+    if (node.children !== undefined) {
       const filtered = filterTree(node.children, query);
       if (filtered.length > 0) {
         result.push({ ...node, children: filtered });
@@ -60,7 +60,7 @@ const FileTreeNode = ({
   onExpand: (dirPath: string) => void;
   onCollapse: (dirPath: string) => void;
 }) => {
-  const isDir = Boolean(node.children);
+  const isDir = node.children !== undefined;
   const isOpen = forceExpand || expandedPaths.has(node.path);
 
   const handleToggleExpand = useCallback(() => {
@@ -158,9 +158,10 @@ export const FileTree = ({ files, selectedPath, onSelect }: FileTreeProps) => {
   const onExpand = useCallback(
     (dirPath: string) => {
       const node = findNode(files, dirPath);
-      const subPaths = node?.children
-        ? computeAutoExpandPaths(node.children)
-        : new Set<string>();
+      const subPaths =
+        node?.children === undefined
+          ? new Set<string>()
+          : computeAutoExpandPaths(node.children);
 
       setExpandedPaths((prev) => {
         if (prev.has(dirPath)) {

--- a/src/client/components/markdown-pre.tsx
+++ b/src/client/components/markdown-pre.tsx
@@ -10,20 +10,22 @@ export const MarkdownPre = ({
 }: ComponentPropsWithoutRef<"pre">) => {
   const codeEl = Array.isArray(children) ? children[0] : children;
 
-  const isMermaid =
-    codeEl &&
+  const isCodeElement =
+    codeEl !== null &&
+    codeEl !== undefined &&
     typeof codeEl === "object" &&
-    "props" in codeEl &&
-    MERMAID_CLASS_RE.test(codeEl.props.className || "");
+    "props" in codeEl;
+
+  const isMermaid =
+    isCodeElement && MERMAID_CLASS_RE.test(codeEl.props.className ?? "");
 
   if (isMermaid) {
     return children;
   }
 
-  const code =
-    codeEl && typeof codeEl === "object" && "props" in codeEl
-      ? String(codeEl.props.children).replace(/\n$/, "")
-      : "";
+  const code = isCodeElement
+    ? String(codeEl.props.children).replace(/\n$/, "")
+    : "";
 
   return (
     <div className="not-prose group rounded-md border border-border bg-code-bg">

--- a/src/client/components/md-link.tsx
+++ b/src/client/components/md-link.tsx
@@ -16,14 +16,14 @@ export const MdLink = ({
   const handleClick = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) => {
       e.preventDefault();
-      if (selectedPath && href) {
+      if (selectedPath !== null && href !== undefined) {
         onNavigate(resolvePath(selectedPath, href));
       }
     },
     [selectedPath, href, onNavigate]
   );
 
-  if (href?.endsWith(".md") && selectedPath) {
+  if (href?.endsWith(".md") === true && selectedPath !== null) {
     return (
       <a {...props} href={href} onClick={handleClick}>
         {children}
@@ -32,7 +32,7 @@ export const MdLink = ({
   }
   // hash-only anchor (rehypeAutolinkHeadings が prepend する見出し anchor を含む) は
   // 同一タブで URL hash を更新したいので target="_blank" を付与しない。
-  if (href?.startsWith("#")) {
+  if (href?.startsWith("#") === true) {
     return (
       <a {...props} href={href}>
         {children}

--- a/src/client/components/quick-open.tsx
+++ b/src/client/components/quick-open.tsx
@@ -30,15 +30,15 @@ interface QuickOpenProps {
 const flattenFiles = (nodes: FileNode[]): FlatFile[] => {
   const result: FlatFile[] = [];
   for (const node of nodes) {
-    if (node.children) {
-      result.push(...flattenFiles(node.children));
-    } else {
+    if (node.children === undefined) {
       const lastSlash = node.path.lastIndexOf("/");
       result.push({
         dir: lastSlash > 0 ? node.path.slice(0, lastSlash) : "",
         name: node.name,
         path: node.path,
       });
+    } else {
+      result.push(...flattenFiles(node.children));
     }
   }
   return result;
@@ -53,7 +53,7 @@ const useQuickOpenSearch = (files: FileNode[], query: string) => {
   );
 
   return useMemo(() => {
-    if (!query) {
+    if (query === "") {
       return allFiles
         .slice(0, 30)
         .map((f) => ({ item: f, positions: new Set<number>() }));

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -8,7 +8,7 @@ import { App } from "./app";
 import "./index.css";
 
 const root = document.querySelector("#root");
-if (root) {
+if (root !== null) {
   createRoot(root).render(
     <StrictMode>
       <ThemeProvider>

--- a/src/client/utils/auto-expand.ts
+++ b/src/client/utils/auto-expand.ts
@@ -4,12 +4,12 @@ export const computeAutoExpandPaths = (nodes: FileNode[]): Set<string> => {
   const paths = new Set<string>();
 
   const walk = (children: FileNode[]) => {
-    const dirs = children.filter((n) => n.children);
+    const dirs = children.filter((n) => n.children !== undefined);
     if (dirs.length !== 1) {
       return;
     }
     paths.add(dirs[0].path);
-    if (dirs[0].children) {
+    if (dirs[0].children !== undefined) {
       walk(dirs[0].children);
     }
   };
@@ -20,11 +20,11 @@ export const computeAutoExpandPaths = (nodes: FileNode[]): Set<string> => {
 
 export const findFirstFile = (nodes: FileNode[]): string | null => {
   for (const node of nodes) {
-    if (!node.children) {
+    if (node.children === undefined) {
       return node.path;
     }
     const child = findFirstFile(node.children);
-    if (child) {
+    if (child !== null) {
       return child;
     }
   }
@@ -39,9 +39,9 @@ export const findNode = (
     if (node.path === path) {
       return node;
     }
-    if (node.children) {
+    if (node.children !== undefined) {
       const found = findNode(node.children, path);
-      if (found) {
+      if (found !== undefined) {
         return found;
       }
     }

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -78,7 +78,7 @@ const setupWatcher = (
         event: "file-changed",
       });
     } else {
-      if (treeDebounceTimer) {
+      if (treeDebounceTimer !== null) {
         clearTimeout(treeDebounceTimer);
       }
       treeDebounceTimer = setTimeout(async () => {
@@ -127,7 +127,7 @@ export const createApiRouter = (
 
   api.get("/api/file", async (c) => {
     const filePath = c.req.query("path");
-    if (!filePath) {
+    if (filePath === undefined || filePath === "") {
       return c.json<ApiErrorResponse>(
         { error: "path query parameter is required" },
         400
@@ -147,7 +147,7 @@ export const createApiRouter = (
 
   api.get("/api/image", async (c) => {
     const filePath = c.req.query("path");
-    if (!filePath) {
+    if (filePath === undefined || filePath === "") {
       return c.json<ApiErrorResponse>(
         { error: "path query parameter is required" },
         400
@@ -170,7 +170,7 @@ export const createApiRouter = (
 
     const stream = new ReadableStream({
       cancel() {
-        if (listener) {
+        if (listener !== null) {
           sseListeners.delete(listener);
         }
       },

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -31,7 +31,7 @@ const registerLifecycle = (app: Hono, onDisconnect: () => void) => {
 
   app.get("/api/lifecycle", (_c) => {
     connections += 1;
-    if (graceTimer) {
+    if (graceTimer !== null) {
       clearTimeout(graceTimer);
       graceTimer = null;
     }
@@ -78,7 +78,7 @@ const createApp = (
 ) => {
   const app = new Hono();
 
-  if (onDisconnect) {
+  if (onDisconnect !== undefined) {
     registerLifecycle(app, onDisconnect);
   }
   app.route("/", createApiRouter(baseDir));
@@ -126,9 +126,9 @@ program
           console.log(`  ➜  Local:   ${localUrl}`);
 
           const ip = networkConfig.enableNetwork ? getLocalIpAddress() : null;
-          const networkUrl = ip ? `http://${ip}:${info.port}` : null;
+          const networkUrl = ip === null ? null : `http://${ip}:${info.port}`;
 
-          if (networkUrl) {
+          if (networkUrl !== null) {
             console.log(`  ➜  Network: ${networkUrl}`);
           } else if (!networkConfig.enableNetwork) {
             console.log("  ➜  Network: use --host to expose to local network");
@@ -137,8 +137,13 @@ program
           console.log("");
           console.log(`  Serving: ${baseDir}`);
 
-          // Dev:host 時は Vite プラグイン側で QR を表示するためスキップ
-          if (networkUrl && !process.env.SPECV_HOST) {
+          // Dev:host 時は Vite プラグイン側で QR を表示するためスキップ。
+          // SPECV_HOST="" は未設定と同義として扱う（`vite.config.ts:93` の Boolean(process.env.SPECV_HOST) と整合）
+          if (
+            networkUrl !== null &&
+            (process.env.SPECV_HOST === undefined ||
+              process.env.SPECV_HOST === "")
+          ) {
             console.log("");
             displayQrCode(networkUrl);
           }

--- a/src/server/network.ts
+++ b/src/server/network.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 export const getLocalIpAddress = (): string | null => {
   const interfaces = os.networkInterfaces();
   for (const addrs of Object.values(interfaces)) {
-    if (!addrs) {
+    if (addrs === undefined) {
       continue;
     }
     for (const addr of addrs) {

--- a/src/server/watcher.ts
+++ b/src/server/watcher.ts
@@ -70,7 +70,7 @@ export const createWatcher = (
   scanExisting(baseDir, knownFiles);
 
   const watcher = fs.watch(baseDir, { recursive: true }, (_event, filename) => {
-    if (!filename) {
+    if (filename === null || filename === "") {
       return;
     }
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -68,6 +68,18 @@ describe("GET /api/file", () => {
     });
   });
 
+  it("?path=（空文字列）で 400 を返す", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const app = createApiRouter(tmpDir);
+      const res = await app.request("/api/file?path=");
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "path query parameter is required",
+      });
+    });
+  });
+
   it("正常な .md ファイルの内容を返す", async () => {
     await withTmpDir(async (tmpDir) => {
       createFile(tmpDir, "README.md", "# Hello World");
@@ -126,6 +138,18 @@ describe("GET /api/image", () => {
       const app = createApiRouter(tmpDir);
       const res = await app.request("/api/image");
       expect(res.status).toBe(400);
+    });
+  });
+
+  it("?path=（空文字列）で 400 を返す", async () => {
+    await withTmpDir(async (tmpDir) => {
+      const app = createApiRouter(tmpDir);
+      const res = await app.request("/api/image?path=");
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        error: "path query parameter is required",
+      });
     });
   });
 

--- a/tests/components/code-block.test.tsx
+++ b/tests/components/code-block.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { CodeBlock } from "@/components/code-block";
+
+vi.mock(import("@/hooks/use-theme"), () => ({
+  useTheme: () => ({ theme: "light" as const, toggle: vi.fn() }),
+}));
+
+vi.mock(import("mermaid"), () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn().mockResolvedValue({
+      bindFunctions: vi.fn(),
+      svg: '<svg data-testid="mermaid-svg">mock</svg>',
+    }),
+  },
+}));
+
+const SAMPLE_TS = "const x = 1;";
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(CodeBlock, () => {
+  // eslint-disable-next-line jest/no-hooks -- jsdom cleanup required
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("language-ts クラスで Highlight 経路の <code> をレンダーする", () => {
+    const { container } = render(
+      <CodeBlock className="language-ts">{SAMPLE_TS}</CodeBlock>
+    );
+
+    expect(container.querySelector("code.language-ts")).not.toBeNull();
+    expect(container.querySelector("code > span")).not.toBeNull();
+  });
+
+  it("className 未指定で素の <code> を返し Highlight 経路に入らない", () => {
+    const { container } = render(<CodeBlock>plain</CodeBlock>);
+
+    expect(screen.getByText("plain")).toBeDefined();
+    expect(container.querySelector("code > span")).toBeNull();
+  });
+
+  it('className="" で素の <code> を返し Highlight 経路に入らない', () => {
+    const { container } = render(<CodeBlock className="">plain</CodeBlock>);
+
+    expect(screen.getByText("plain")).toBeDefined();
+    expect(container.querySelector("code > span")).toBeNull();
+  });
+
+  it("language-mermaid クラスで MermaidBlock を Suspense 経由で描画する", async () => {
+    render(
+      <CodeBlock className="language-mermaid">{"graph TD;A-->B"}</CodeBlock>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mermaid-svg")).toBeDefined();
+    });
+  });
+
+  it("language- 接頭辞を含まない className で素の <code> を返す", () => {
+    const { container } = render(
+      <CodeBlock className="weird-class">plain</CodeBlock>
+    );
+
+    expect(screen.getByText("plain")).toBeDefined();
+    expect(container.querySelector("code > span")).toBeNull();
+  });
+});

--- a/tests/components/markdown-pre.test.tsx
+++ b/tests/components/markdown-pre.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { MarkdownPre } from "@/components/markdown-pre";
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(MarkdownPre, () => {
+  // eslint-disable-next-line jest/no-hooks -- jsdom cleanup required
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("language-ts の codeEl を <pre> + CopyButton でラップする", () => {
+    const { container } = render(
+      <MarkdownPre>
+        <code className="language-ts">const x = 1;</code>
+      </MarkdownPre>
+    );
+
+    expect(container.querySelector("pre")).not.toBeNull();
+    expect(screen.getByTitle("Copy")).toBeDefined();
+  });
+
+  it('codeEl の className="" でも <pre> ラップ経路に入る', () => {
+    const { container } = render(
+      <MarkdownPre>
+        <code className="">x</code>
+      </MarkdownPre>
+    );
+
+    expect(container.querySelector("pre")).not.toBeNull();
+    expect(screen.getByTitle("Copy")).toBeDefined();
+  });
+
+  it("codeEl の className 未指定でも <pre> ラップ経路に入る", () => {
+    const { container } = render(
+      <MarkdownPre>
+        <code>x</code>
+      </MarkdownPre>
+    );
+
+    expect(container.querySelector("pre")).not.toBeNull();
+    expect(screen.getByTitle("Copy")).toBeDefined();
+  });
+
+  it("language-mermaid の codeEl は children passthrough で <pre> を出さない", () => {
+    const { container } = render(
+      <MarkdownPre>
+        <code className="language-mermaid">{"graph TD;A-->B"}</code>
+      </MarkdownPre>
+    );
+
+    expect(screen.queryByTitle("Copy")).toBeNull();
+    expect(container.querySelector("pre")).toBeNull();
+    expect(container.querySelector("code.language-mermaid")).not.toBeNull();
+  });
+
+  it("プリミティブな children でも <pre> + CopyButton でラップする", () => {
+    const { container } = render(<MarkdownPre>{"raw text"}</MarkdownPre>);
+
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain("raw text");
+    expect(screen.getByTitle("Copy")).toBeDefined();
+  });
+});

--- a/tests/components/quick-open.test.tsx
+++ b/tests/components/quick-open.test.tsx
@@ -48,6 +48,27 @@ describe("quick-open", () => {
     expect(screen.getByPlaceholderText("Go to File")).toBeDefined();
   });
 
+  it("query が空のとき全ファイル候補が描画される", () => {
+    render(
+      <QuickOpen files={sampleFiles} open onClose={noop} onSelect={noop} />
+    );
+
+    const items = document.querySelectorAll("[cmdk-item]");
+    const hasReadme = [...items].some((el) =>
+      el.textContent?.includes("README.md")
+    );
+    const hasIndex = [...items].some((el) =>
+      el.textContent?.includes("index.ts")
+    );
+    const hasUtils = [...items].some((el) =>
+      el.textContent?.includes("utils.ts")
+    );
+
+    expect(hasReadme).toBeTruthy();
+    expect(hasIndex).toBeTruthy();
+    expect(hasUtils).toBeTruthy();
+  });
+
   it("open=false で何も表示されない", () => {
     render(
       <QuickOpen

--- a/vite-plugin-qrcode.ts
+++ b/vite-plugin-qrcode.ts
@@ -6,18 +6,22 @@ import { displayQrCode } from "./src/server/qr-display.ts";
 export const qrcodePlugin = (): Plugin => ({
   apply: "serve",
   configureServer(server) {
-    if (!process.env.SPECV_HOST) {
+    if (process.env.SPECV_HOST === undefined || process.env.SPECV_HOST === "") {
       return;
     }
 
     server.httpServer?.once("listening", () => {
       const ip = getLocalIpAddress();
-      if (!ip) {
+      if (ip === null) {
         return;
       }
 
       const address = server.httpServer?.address();
-      if (!address || typeof address === "string") {
+      if (
+        address === null ||
+        address === undefined ||
+        typeof address === "string"
+      ) {
         return;
       }
 


### PR DESCRIPTION
## Summary

## 概要

issue #126（Vite+ の type-aware lint 有効化）の段階導入として、`typescript/strict-boolean-expressions` の違反を解消する。

## 親 issue

#126

## 対象ルール

| ルール | 想定件数 | 内容 |
|---|---|---|
| `typescript/strict-boolean-expressions` | 30 | nullable string / number / object などを `if` / `&&` / `||` 等で暗黙 boolean 評価している箇所 |

PR #125 時点の計測で 30 件。本 issue で最大件数のカテゴリ。

## 典型パターン

```ts
// ❌ NG: process.env.X は string | undefined
if (process.env.X) { ... }

// ✅ OK: 明示的な存在チェック
if (process.env.X !== undefined) { ... }
if (process.env.X != null) { ... }

// ❌ NG: nullable string の OR fallback
const value = props.label || "default";

// ✅ OK: nullish coalescing
const value = props.label ?? "default";
```

## 進め方

1. ローカルで `lint.options.typeAware: true` / `typeCheck: true` を一時的に有効にして違反箇所を列挙
2. パターンごとに一括修正（`!== undefined` / `!= null` / `??` への置換）
3. 単純な書き換えで意味が変わるケース（空文字列を falsy として使っているなど）は個別判断
4. 修正後、type-aware を再度 off に戻す（本 PR では有効化しない）

## 受け入れ基準

- [ ] type-aware を有効化しても `typescript/strict-boolean-expressions` が 0 件
- [ ] `nr test` / `nr test:e2e` が通る
- [ ] `nr check` が通る
- [ ] 空文字列 / 数値 0 を falsy として扱う既存ロジックの挙動が変わっていない（unit test で担保）

## メモ

- ルール自体は **off にしない**（issue #126 のゴールは「全ルール on のまま typeAware: true」）
- 件数が多いので、auto-fix が安全に効くケース（`||` → `??` 等）と手動判断が必要なケースを分けて進める

## Execution Report

Workflow `default` completed successfully.

Closes #129