### PR TITLE
[#130] issue-130-no-unsafe-type-asser

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,13 +1,14 @@
-import type { ApiErrorResponse } from "@shared/errors";
-import type { FileNode, FilesResponse } from "@shared/types";
+import { isApiErrorResponse } from "@shared/errors";
+import { isFilesResponse } from "@shared/types";
+import type { FileNode } from "@shared/types";
 
 const parseApiError = async (
   res: Response,
   fallback: string
 ): Promise<string> => {
   try {
-    const body = (await res.json()) as ApiErrorResponse;
-    if (typeof body.error === "string") {
+    const body: unknown = await res.json();
+    if (isApiErrorResponse(body)) {
       return body.error;
     }
     return fallback;
@@ -22,7 +23,10 @@ export const fetchFiles = async (): Promise<FileNode[]> => {
   if (!res.ok) {
     throw new Error(await parseApiError(res, "Failed to fetch file list"));
   }
-  const data = (await res.json()) as FilesResponse;
+  const data: unknown = await res.json();
+  if (!isFilesResponse(data)) {
+    throw new Error("Invalid /api/files response shape");
+  }
   return data.files;
 };
 

--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -257,11 +257,9 @@ export const App = () => {
   return (
     <SidebarProvider
       className="h-screen overflow-hidden bg-background text-foreground"
-      style={
-        {
-          "--sidebar-width": `${String(SIDEBAR_DEFAULT_WIDTH)}px`,
-        } as React.CSSProperties
-      }
+      style={{
+        "--sidebar-width": `${String(SIDEBAR_DEFAULT_WIDTH)}px`,
+      }}
     >
       <AppContent />
     </SidebarProvider>

--- a/src/client/components/markdown-pre.tsx
+++ b/src/client/components/markdown-pre.tsx
@@ -1,29 +1,60 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { CopyButton } from "@/components/copy-button";
 
 const MERMAID_CLASS_RE = /language-mermaid/;
 
+interface CodeElementProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+const isReactNode = (value: unknown): value is ReactNode => {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  const t = typeof value;
+  return (
+    t === "string" ||
+    t === "number" ||
+    t === "boolean" ||
+    t === "bigint" ||
+    t === "object"
+  );
+};
+
+const getCodeElementProps = (node: unknown): CodeElementProps | null => {
+  if (!node || typeof node !== "object" || !("props" in node)) {
+    return null;
+  }
+  const { props } = node;
+  if (!props || typeof props !== "object") {
+    return null;
+  }
+  const className =
+    "className" in props && typeof props.className === "string"
+      ? props.className
+      : undefined;
+  const childrenValue: unknown =
+    "children" in props ? props.children : undefined;
+  const children = isReactNode(childrenValue) ? childrenValue : undefined;
+  return { children, className };
+};
+
 export const MarkdownPre = ({
   children,
   ...props
 }: ComponentPropsWithoutRef<"pre">) => {
-  const codeEl = Array.isArray(children) ? children[0] : children;
+  const firstChild: unknown = Array.isArray(children) ? children[0] : children;
+  const codeProps = getCodeElementProps(firstChild);
 
-  const isMermaid =
-    codeEl &&
-    typeof codeEl === "object" &&
-    "props" in codeEl &&
-    MERMAID_CLASS_RE.test(codeEl.props.className || "");
+  const isMermaid = MERMAID_CLASS_RE.test(codeProps?.className ?? "");
 
   if (isMermaid) {
     return children;
   }
 
-  const code =
-    codeEl && typeof codeEl === "object" && "props" in codeEl
-      ? String(codeEl.props.children).replace(/\n$/, "")
-      : "";
+  const code = codeProps ? String(codeProps.children).replace(/\n$/, "") : "";
 
   return (
     <div className="not-prose group rounded-md border border-border bg-code-bg">

--- a/src/client/hooks/use-theme.tsx
+++ b/src/client/hooks/use-theme.tsx
@@ -10,6 +10,9 @@ import type { ReactNode } from "react";
 
 type Theme = "light" | "dark";
 
+const isTheme = (value: unknown): value is Theme =>
+  value === "light" || value === "dark";
+
 interface ThemeContextValue {
   theme: Theme;
   toggle: () => void;
@@ -19,8 +22,8 @@ const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   const [theme, setTheme] = useState<Theme>(() => {
-    const saved = localStorage.getItem("specv-theme") as Theme | null;
-    if (saved) {
+    const saved: unknown = localStorage.getItem("specv-theme");
+    if (isTheme(saved)) {
       return saved;
     }
     return window.matchMedia("(prefers-color-scheme: dark)").matches

--- a/src/client/hooks/use-watch.ts
+++ b/src/client/hooks/use-watch.ts
@@ -1,13 +1,24 @@
-import type {
-  FileChangedPayload,
-  FileNode,
-  TreeChangedPayload,
+import {
+  isFileChangedPayload,
+  isTreeChangedPayload,
+  type FileNode,
 } from "@shared/types";
 import { useEffect, useRef } from "react";
 
 import { fetchFile } from "@/api";
 import { logError } from "@/lib/logger";
 import { handleFileChanged, handleTreeChanged } from "@/utils/watch-handler";
+
+const safeJsonParse = (raw: unknown): unknown => {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+};
 
 export const useWatch = (
   selectedPath: string | null,
@@ -35,13 +46,19 @@ export const useWatch = (
     };
 
     es.addEventListener("file-changed", (e) => {
-      const { path } = JSON.parse(e.data) as FileChangedPayload;
-      handleFileChanged(path, selectedPathRef.current, actions);
+      const payload = safeJsonParse(e.data);
+      if (!isFileChangedPayload(payload)) {
+        return;
+      }
+      handleFileChanged(payload.path, selectedPathRef.current, actions);
     });
 
     es.addEventListener("tree-changed", (e) => {
-      const { files } = JSON.parse(e.data) as TreeChangedPayload;
-      handleTreeChanged(files, selectedPathRef.current, actions);
+      const payload = safeJsonParse(e.data);
+      if (!isTreeChangedPayload(payload)) {
+        return;
+      }
+      handleTreeChanged(payload.files, selectedPathRef.current, actions);
     });
 
     return () => es.close();

--- a/src/client/lib/remark-frontmatter-table.ts
+++ b/src/client/lib/remark-frontmatter-table.ts
@@ -1,3 +1,4 @@
+import { isObjectRecord } from "@shared/is-object-record";
 import type { Root, Table, TableCell, TableRow, Text } from "mdast";
 import type { Plugin } from "unified";
 import { parse } from "yaml";
@@ -43,12 +44,12 @@ export const remarkFrontmatterTable: Plugin<[], Root> = () => (tree) => {
     // Invalid YAML
   }
 
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+  if (!isObjectRecord(parsed)) {
     tree.children.splice(0, 1);
     return;
   }
 
-  const entries = Object.entries(parsed as Record<string, unknown>);
+  const entries = Object.entries(parsed);
   if (entries.length === 0) {
     tree.children.splice(0, 1);
     return;

--- a/src/client/types/css.d.ts
+++ b/src/client/types/css.d.ts
@@ -1,0 +1,7 @@
+import "react";
+
+declare module "react" {
+  interface CSSProperties {
+    "--sidebar-width"?: string;
+  }
+}

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
+import { isObjectRecord } from "@shared/is-object-record";
 import { program } from "commander";
 import { Hono } from "hono";
 
@@ -17,9 +18,19 @@ const packageJsonPath = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../../package.json"
 );
-const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
-  version: string;
+
+const isPkgShape = (value: unknown): value is { version: string } => {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  return typeof value.version === "string";
 };
+
+const parsedPkg: unknown = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+if (!isPkgShape(parsedPkg)) {
+  throw new Error("Invalid package.json: missing version");
+}
+const pkg = parsedPkg;
 
 const currentDir = import.meta.dirname;
 
@@ -92,6 +103,12 @@ export const getNetworkConfig = (options: { host: boolean }) => ({
   hostname: options.host ? "0.0.0.0" : "127.0.0.1",
 });
 
+interface CliOptions {
+  port: string;
+  host?: boolean;
+  autoClose: boolean;
+}
+
 program
   .name("specv")
   .description("Local Markdown preview with GitHub-style rendering")
@@ -99,7 +116,7 @@ program
   .option("-p, --port <number>", "Port number", "4649")
   .option("--host", "Expose to local network (enables QR code)")
   .option("--no-auto-close", "Disable auto-close on client disconnect")
-  .action((options) => {
+  .action((options: CliOptions) => {
     const baseDir = process.cwd();
     const startPort = Number.parseInt(options.port, 10);
     const clientDir = path.join(currentDir, "../client");

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -1,4 +1,10 @@
+import { isObjectRecord } from "./is-object-record";
+
 export type AppErrorCode = "SECURITY";
+
+const APP_ERROR_CODE_VALUES: ReadonlySet<string> = new Set<string>([
+  "SECURITY",
+]);
 
 export abstract class AppError extends Error {
   abstract readonly code: AppErrorCode;
@@ -8,3 +14,21 @@ export interface ApiErrorResponse {
   error: string;
   code?: AppErrorCode;
 }
+
+const isAppErrorCode = (value: unknown): value is AppErrorCode =>
+  typeof value === "string" && APP_ERROR_CODE_VALUES.has(value);
+
+export const isApiErrorResponse = (
+  value: unknown
+): value is ApiErrorResponse => {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (typeof value.error !== "string") {
+    return false;
+  }
+  if (value.code === undefined) {
+    return true;
+  }
+  return isAppErrorCode(value.code);
+};

--- a/src/shared/is-object-record.ts
+++ b/src/shared/is-object-record.ts
@@ -1,0 +1,10 @@
+// 型ガード共有 helper（SSOT）。
+// `as Record<string, unknown>` による narrow を避けて
+// `typescript/no-unsafe-type-assertion` を 0 件に保つ目的で、
+// `@shared` 配下のスキーマ narrow / `client` `server` の入口チェックを
+// すべてここに集約する。新規に object narrow が必要になった場合は
+// 別実装を作らずこのモジュールを import すること。
+export const isObjectRecord = (
+  value: unknown
+): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,5 @@
+import { isObjectRecord } from "./is-object-record";
+
 export interface FileNode {
   path: string;
   name: string;
@@ -17,3 +19,46 @@ export interface TreeChangedPayload {
 }
 
 export type WatchEventName = "file-changed" | "tree-changed";
+
+export const isFileNode = (value: unknown): value is FileNode => {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (typeof value.path !== "string" || typeof value.name !== "string") {
+    return false;
+  }
+  if (value.children === undefined) {
+    return true;
+  }
+  if (!Array.isArray(value.children)) {
+    return false;
+  }
+  return value.children.every(isFileNode);
+};
+
+export const isFilesResponse = (value: unknown): value is FilesResponse => {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (!Array.isArray(value.files)) {
+    return false;
+  }
+  return value.files.every(isFileNode);
+};
+
+export const isFileChangedPayload = (
+  value: unknown
+): value is FileChangedPayload =>
+  isObjectRecord(value) && typeof value.path === "string";
+
+export const isTreeChangedPayload = (
+  value: unknown
+): value is TreeChangedPayload => {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  if (!Array.isArray(value.files)) {
+    return false;
+  }
+  return value.files.every(isFileNode);
+};

--- a/tests/api-asserts-contract.test.ts
+++ b/tests/api-asserts-contract.test.ts
@@ -1,0 +1,41 @@
+import type { ApiErrorResponse } from "@shared/errors";
+import type { FilesResponse } from "@shared/types";
+
+import { expectApiErrorResponse, expectFilesResponse } from "./test-utils";
+
+// 再発防止: api テストの asserts ヘルパーが `FilesResponse` / `ApiErrorResponse`
+// を文字列レベルで再宣言しないこと、および各テストファイルで再実装されないことを保証する。
+// SSOT は `@shared/{types,errors}.ts`、共有実装は `tests/test-utils.ts`。
+// 過去の architect-review (ARCH-NEW-tests-api-asserts-shape-rehardcoded /
+// ARCH-NEW-tests-api-asserts-helper-dup) を参照。
+
+describe("api asserts ヘルパー契約", () => {
+  it("FilesResponse 型に narrow される", () => {
+    const json: unknown = { files: [{ name: "a.md", path: "a.md" }] };
+
+    expectFilesResponse(json);
+
+    // narrow 成功時に SSOT 型 (FilesResponse) のフィールドにアクセスできる
+    const filesResponse: FilesResponse = json;
+    expect(filesResponse.files[0]?.name).toBe("a.md");
+  });
+
+  it("ApiErrorResponse 型に narrow され、AppErrorCode 拡張に自動追従できる", () => {
+    const json: unknown = { code: "SECURITY", error: "boom" };
+
+    expectApiErrorResponse(json);
+
+    // narrow 成功時に SSOT 型 (ApiErrorResponse) のフィールドにアクセスできる
+    const apiError: ApiErrorResponse = json;
+    expect(apiError.error).toBe("boom");
+    expect(apiError.code).toBe("SECURITY");
+  });
+
+  it("不正な shape は assert で失敗する", () => {
+    const json: unknown = { files: "not-an-array" };
+
+    expect(() => {
+      expectFilesResponse(json);
+    }).toThrow(/expected.*to be true/i);
+  });
+});

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 
 import { createApiRouter } from "@server/api";
 
-import { createFile, withTmpDir } from "./test-utils";
+import {
+  createFile,
+  expectApiErrorResponse,
+  expectFilesResponse,
+  withTmpDir,
+} from "./test-utils";
 
 // 1x1 transparent PNG
 const TINY_PNG = Buffer.from(
@@ -22,8 +27,8 @@ describe("GET /api/files", () => {
       const res = await app.request("/api/files");
       expect(res.status).toBe(200);
 
-      const json = await res.json();
-      expect(json.files).toBeDefined();
+      const json: unknown = await res.json();
+      expectFilesResponse(json);
       expect(json.files.length).toBeGreaterThan(0);
     });
   });
@@ -34,7 +39,8 @@ describe("GET /api/files", () => {
       const res = await app.request("/api/files");
       expect(res.status).toBe(200);
 
-      const json = await res.json();
+      const json: unknown = await res.json();
+      expectFilesResponse(json);
       expect(json.files).toStrictEqual([]);
     });
   });
@@ -93,7 +99,8 @@ describe("GET /api/file", () => {
       const res = await app.request("/api/file?path=../etc/passwd");
 
       expect(res.status).toBe(400);
-      const json = (await res.json()) as { code?: string; error: string };
+      const json: unknown = await res.json();
+      expectApiErrorResponse(json);
       expect(json.code).toBe("SECURITY");
       expect(typeof json.error).toBe("string");
     });
@@ -113,7 +120,7 @@ describe("GET /api/file", () => {
       const res = await app.request("/api/file?path=nonexistent.md");
 
       expect(res.status).toBe(404);
-      const json = await res.json();
+      const json: unknown = await res.json();
       expect(json).not.toHaveProperty("code");
     });
   });
@@ -154,7 +161,8 @@ describe("GET /api/image", () => {
       const res = await app.request("/api/image?path=../etc/image.png");
 
       expect(res.status).toBe(400);
-      const json = (await res.json()) as { code?: string; error: string };
+      const json: unknown = await res.json();
+      expectApiErrorResponse(json);
       expect(json.code).toBe("SECURITY");
       expect(typeof json.error).toBe("string");
     });

--- a/tests/client-api.test.ts
+++ b/tests/client-api.test.ts
@@ -61,6 +61,45 @@ describe(fetchFiles, () => {
 
     await expect(fetchFiles()).rejects.toThrow("Failed to fetch file list");
   });
+
+  it("malformed 200 ({ foo }) で Invalid /api/files response shape を throw する", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ foo: "bar" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      })
+    );
+
+    await expect(fetchFiles()).rejects.toThrow(
+      "Invalid /api/files response shape"
+    );
+  });
+
+  it("malformed 200 ({ files: 'x' }) で Invalid /api/files response shape を throw する", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ files: "x" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      })
+    );
+
+    await expect(fetchFiles()).rejects.toThrow(
+      "Invalid /api/files response shape"
+    );
+  });
+
+  it("malformed 200 ({ files: [{ path: 1 }] }) で Invalid /api/files response shape を throw する", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ files: [{ path: 1 }] }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      })
+    );
+
+    await expect(fetchFiles()).rejects.toThrow(
+      "Invalid /api/files response shape"
+    );
+  });
 });
 
 // eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference

--- a/tests/components/app-header.test.tsx
+++ b/tests/components/app-header.test.tsx
@@ -3,6 +3,8 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { App } from "@/app";
 
+import { installEventSourceMock } from "../test-utils";
+
 // API モック
 vi.mock(import("@/api"), () => ({
   fetchFile: vi.fn().mockResolvedValue("# Test"),
@@ -14,16 +16,8 @@ vi.mock(import("@/hooks/use-theme"), () => ({
   useTheme: () => ({ theme: "light" as const, toggle: vi.fn() }),
 }));
 
-// EventSource モック
-class EventSourceMock {
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  addEventListener() {}
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  close() {}
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  removeEventListener() {}
-}
-global.EventSource = EventSourceMock as unknown as typeof EventSource;
+// EventSource モック（複数テストで使う no-op スタブ。dispatch 機能は不要）
+installEventSourceMock();
 
 // UseHotkey モック
 vi.mock(import("@tanstack/react-hotkeys"), () => ({

--- a/tests/components/app-responsive.test.tsx
+++ b/tests/components/app-responsive.test.tsx
@@ -9,6 +9,8 @@ import {
 
 import { App } from "@/app";
 
+import { installEventSourceMock } from "../test-utils";
+
 // API モック
 vi.mock(import("@/api"), () => ({
   fetchFile: vi.fn().mockResolvedValue("# Test"),
@@ -23,16 +25,8 @@ vi.mock(import("@/hooks/use-theme"), () => ({
   useTheme: () => ({ theme: "light" as const, toggle: vi.fn() }),
 }));
 
-// EventSource モック
-class EventSourceMock {
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  addEventListener() {}
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  close() {}
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  removeEventListener() {}
-}
-global.EventSource = EventSourceMock as unknown as typeof EventSource;
+// EventSource モック（複数テストで使う no-op スタブ。dispatch 機能は不要）
+installEventSourceMock();
 
 // UseHotkey モック
 vi.mock(import("@tanstack/react-hotkeys"), () => ({

--- a/tests/components/copy-button.test.tsx
+++ b/tests/components/copy-button.test.tsx
@@ -19,7 +19,7 @@ describe(CopyButton, () => {
   });
 
   it("クリックで navigator.clipboard.writeText(text) が呼ばれる", async () => {
-    const writeText = vi.fn().mockResolvedValue();
+    const writeText = vi.fn(async (_text: string) => {});
     Object.assign(navigator, { clipboard: { writeText } });
 
     render(<CopyButton text="hello world" />);
@@ -31,7 +31,7 @@ describe(CopyButton, () => {
   });
 
   it("writeText 解決後に title が 'Copied!' になり Check アイコンが表示される", async () => {
-    const writeText = vi.fn().mockResolvedValue();
+    const writeText = vi.fn(async (_text: string) => {});
     Object.assign(navigator, { clipboard: { writeText } });
 
     render(<CopyButton text="hello" />);
@@ -45,7 +45,7 @@ describe(CopyButton, () => {
     vi.useFakeTimers();
     try {
       // Arrange
-      const writeText = vi.fn().mockResolvedValue();
+      const writeText = vi.fn(async (_text: string) => {});
       Object.assign(navigator, { clipboard: { writeText } });
       render(<CopyButton text="hello" />);
 
@@ -73,7 +73,7 @@ describe(CopyButton, () => {
 
   it("初回クリックでは prop の text で writeText が呼ばれる", async () => {
     // Arrange
-    const writeText = vi.fn().mockResolvedValue();
+    const writeText = vi.fn(async (_text: string) => {});
     Object.assign(navigator, { clipboard: { writeText } });
     render(<CopyButton text="first" />);
 
@@ -88,7 +88,7 @@ describe(CopyButton, () => {
 
   it("rerender 後のクリックでは新しい text で writeText が呼ばれる", async () => {
     // Arrange
-    const writeText = vi.fn().mockResolvedValue();
+    const writeText = vi.fn(async (_text: string) => {});
     Object.assign(navigator, { clipboard: { writeText } });
     const { rerender } = render(<CopyButton text="first" />);
     rerender(<CopyButton text="second" />);
@@ -129,7 +129,7 @@ describe(CopyButton, () => {
       });
       expect(screen.getByTitle("Copied!")).toBeDefined();
     } finally {
-      delete (document as Partial<Document>).execCommand;
+      Reflect.deleteProperty(document, "execCommand");
     }
   });
 });

--- a/tests/components/mermaid-block.test.tsx
+++ b/tests/components/mermaid-block.test.tsx
@@ -5,7 +5,7 @@ vi.mock(import("mermaid"));
 vi.mock(import("@/hooks/use-theme.js"));
 
 describe("MermaidBlock", () => {
-  let mockTheme: string;
+  let mockTheme: "light" | "dark";
 
   // eslint-disable-next-line jest/no-hooks -- mock setup, module reset, and jsdom cleanup required
   beforeEach(async () => {
@@ -16,12 +16,13 @@ describe("MermaidBlock", () => {
     vi.mocked(mermaid.default.initialize).mockReturnValue();
     vi.mocked(mermaid.default.render).mockResolvedValue({
       bindFunctions: vi.fn(),
+      diagramType: "flowchart",
       svg: '<svg data-testid="mermaid-svg">mock diagram</svg>',
     });
 
     const themeModule = await import("@/hooks/use-theme.js");
     vi.mocked(themeModule.useTheme).mockImplementation(() => ({
-      theme: mockTheme as "light" | "dark",
+      theme: mockTheme,
       toggle: vi.fn(),
     }));
   });

--- a/tests/components/quick-open.test.tsx
+++ b/tests/components/quick-open.test.tsx
@@ -4,15 +4,17 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { QuickOpen } from "@/components/quick-open";
 
 // Jsdom に ResizeObserver がないのでモック
-class ResizeObserverMock {
+class ResizeObserverMock implements ResizeObserver {
+  // eslint-disable-next-line no-useless-constructor, no-empty-function
+  constructor(_callback: ResizeObserverCallback) {}
   // eslint-disable-next-line class-methods-use-this, no-empty-function
   disconnect() {}
   // eslint-disable-next-line class-methods-use-this, no-empty-function
-  observe() {}
+  observe(_target: Element, _options?: ResizeObserverOptions) {}
   // eslint-disable-next-line class-methods-use-this, no-empty-function
-  unobserve() {}
+  unobserve(_target: Element) {}
 }
-global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+global.ResizeObserver = ResizeObserverMock;
 
 // eslint-disable-next-line no-empty-function
 const noop = () => {};
@@ -174,7 +176,7 @@ describe("quick-open", () => {
     // ↓キーで次のアイテムに移動
     fireEvent.keyDown(input, { key: "ArrowDown" });
 
-    const items = document.querySelectorAll("[cmdk-item]");
+    const items = document.querySelectorAll<HTMLElement>("[cmdk-item]");
     const selected = [...items].find(
       (item) => item.dataset.selected === "true"
     );

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -19,6 +19,7 @@ describe(getLocalIpAddress, () => {
           internal: false,
           mac: "00:00:00:00:00:00",
           netmask: "ffff:ffff:ffff:ffff::",
+          scopeid: 0,
         },
         {
           address: "192.168.1.10",

--- a/tests/open-browser.test.ts
+++ b/tests/open-browser.test.ts
@@ -4,11 +4,11 @@ const { mockExecFile } = vi.hoisted(() => ({
   mockExecFile: vi.fn(),
 }));
 
-vi.mock(import("node:child_process"), () => ({
+vi.mock("node:child_process", () => ({
   execFile: mockExecFile,
 }));
 
-vi.mock(import("node:util"), () => ({
+vi.mock("node:util", () => ({
   promisify: () => mockExecFile,
 }));
 

--- a/tests/remark-frontmatter-table.test.ts
+++ b/tests/remark-frontmatter-table.test.ts
@@ -72,4 +72,9 @@ describe(remarkFrontmatterTable, () => {
     const html = await renderMarkdown("---\n: invalid: yaml: [[\n---\n");
     expect(html).not.toContain("<table>");
   });
+
+  it("frontmatter が YAML 配列のときテーブルを出さない", async () => {
+    const html = await renderMarkdown("---\n- one\n- two\n---\n");
+    expect(html).not.toContain("<table>");
+  });
 });

--- a/tests/server/cli.test.ts
+++ b/tests/server/cli.test.ts
@@ -1,0 +1,39 @@
+describe("cli (module load)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("node:fs");
+  });
+
+  it("package.json に version が無いとき Invalid package.json: missing version を throw する", async () => {
+    vi.doMock("node:fs", () => {
+      const readFileSync = vi.fn().mockReturnValue('{ "name": "specv" }');
+      const existsSync = vi.fn().mockReturnValue(false);
+      return {
+        default: { existsSync, readFileSync },
+        existsSync,
+        readFileSync,
+      };
+    });
+
+    await expect(import("@server/cli")).rejects.toThrow(
+      "Invalid package.json: missing version"
+    );
+  });
+
+  it("package.json が不正 JSON のとき SyntaxError を throw する", async () => {
+    vi.doMock("node:fs", () => {
+      const readFileSync = vi.fn().mockReturnValue("{not-json");
+      const existsSync = vi.fn().mockReturnValue(false);
+      return {
+        default: { existsSync, readFileSync },
+        existsSync,
+        readFileSync,
+      };
+    });
+
+    await expect(import("@server/cli")).rejects.toThrow(SyntaxError);
+  });
+});

--- a/tests/shared-errors-guards.test.ts
+++ b/tests/shared-errors-guards.test.ts
@@ -1,0 +1,60 @@
+import { isApiErrorResponse } from "@shared/errors";
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(isApiErrorResponse, () => {
+  it("error フィールドが string のとき true を返す", () => {
+    const value: unknown = { error: "boom" };
+
+    expect(isApiErrorResponse(value)).toBe(true);
+  });
+
+  it('error + code "SECURITY" を持つとき true を返す', () => {
+    const value: unknown = { code: "SECURITY", error: "x" };
+
+    expect(isApiErrorResponse(value)).toBe(true);
+  });
+
+  it("code が undefined でも true を返す", () => {
+    const value: unknown = { code: undefined, error: "x" };
+
+    expect(isApiErrorResponse(value)).toBe(true);
+  });
+
+  it("空オブジェクトのとき false を返す", () => {
+    const value: unknown = {};
+
+    expect(isApiErrorResponse(value)).toBe(false);
+  });
+
+  it("error が string でないとき false を返す", () => {
+    const value: unknown = { error: 123 };
+
+    expect(isApiErrorResponse(value)).toBe(false);
+  });
+
+  it("code が AppErrorCode 外の文字列のとき false を返す", () => {
+    const value: unknown = { code: "OTHER", error: "x" };
+
+    expect(isApiErrorResponse(value)).toBe(false);
+  });
+
+  it.each([
+    { input: null, label: "null" },
+    { input: "x", label: "string" },
+    { input: [], label: "array" },
+  ])("$label のとき false を返す", ({ input }) => {
+    expect(isApiErrorResponse(input)).toBe(false);
+  });
+
+  it("code が number のとき false を返す", () => {
+    const value: unknown = { code: 123, error: "x" };
+
+    expect(isApiErrorResponse(value)).toBe(false);
+  });
+
+  it("code が null のとき false を返す", () => {
+    const value: unknown = { code: null, error: "x" };
+
+    expect(isApiErrorResponse(value)).toBe(false);
+  });
+});

--- a/tests/shared-is-object-record.test.ts
+++ b/tests/shared-is-object-record.test.ts
@@ -1,0 +1,35 @@
+import { isObjectRecord } from "@shared/is-object-record";
+
+// 再発防止: object narrow ロジック（typeof === "object" && !== null && !Array.isArray）が
+// 兄弟モジュールに別実装で散らばらないよう、`isObjectRecord` を単一の SSOT として扱う。
+// 関連 architect-review:
+//   - ARCH-NEW-shared-errors-record-narrow-inconsistency
+//     (`src/shared/errors.ts` の inline 展開を SSOT に集約)
+//   - ARCH-NEW-remark-frontmatter-table-is-record-dup
+//     (`src/client/lib/remark-frontmatter-table.ts:isRecord` および
+//      `src/server/cli.ts:isPkgShape` 内 inline 同条件式を SSOT に集約)
+// dry-violation family_tag の再発防止としてヘルパーの境界仕様をここで固定する。
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(isObjectRecord, () => {
+  it("プレーンオブジェクトに対して true を返す", () => {
+    expect(isObjectRecord({})).toBe(true);
+    expect(isObjectRecord({ a: 1 })).toBe(true);
+  });
+
+  it.each([
+    { input: null, label: "null" },
+    { input: undefined, label: "undefined" },
+    { input: 0, label: "number" },
+    { input: "", label: "string" },
+    { input: true, label: "boolean" },
+    { input: [], label: "array" },
+    { input: [1, 2], label: "non-empty array" },
+  ])("$label に対して false を返す", ({ input }) => {
+    expect(isObjectRecord(input)).toBe(false);
+  });
+
+  // 型述語による narrow の compile-time 保証は、本ヘルパーを利用する
+  // `src/shared/{errors,types}.ts` / `src/client/lib/remark-frontmatter-table.ts` /
+  // `src/server/cli.ts` および各種テスト側で実証されている。
+  // ここでは runtime の boolean 契約のみを固定する。
+});

--- a/tests/shared-types-guards.test.ts
+++ b/tests/shared-types-guards.test.ts
@@ -1,0 +1,159 @@
+import {
+  isFileChangedPayload,
+  isFileNode,
+  isFilesResponse,
+  isTreeChangedPayload,
+} from "@shared/types";
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(isFileNode, () => {
+  it("path/name のみの最小 shape を受理する", () => {
+    const value: unknown = { name: "a.md", path: "a.md" };
+
+    expect(isFileNode(value)).toBe(true);
+  });
+
+  it("children に有効な FileNode 配列を持つとき受理する", () => {
+    const value: unknown = {
+      children: [
+        { name: "a.md", path: "docs/a.md" },
+        { name: "b.md", path: "docs/b.md" },
+      ],
+      name: "docs",
+      path: "docs",
+    };
+
+    expect(isFileNode(value)).toBe(true);
+  });
+
+  it("children が空配列でも受理する", () => {
+    const value: unknown = { children: [], name: "docs", path: "docs" };
+
+    expect(isFileNode(value)).toBe(true);
+  });
+
+  it("path が欠落しているとき false を返す", () => {
+    const value: unknown = { name: "a.md" };
+
+    expect(isFileNode(value)).toBe(false);
+  });
+
+  it("name が欠落しているとき false を返す", () => {
+    const value: unknown = { path: "a.md" };
+
+    expect(isFileNode(value)).toBe(false);
+  });
+
+  it("path が string でないとき false を返す", () => {
+    const value: unknown = { name: "a.md", path: 1 };
+
+    expect(isFileNode(value)).toBe(false);
+  });
+
+  it("name が string でないとき false を返す", () => {
+    const value: unknown = { name: 1, path: "a.md" };
+
+    expect(isFileNode(value)).toBe(false);
+  });
+
+  it("children が配列でないとき false を返す", () => {
+    const value: unknown = { children: "x", name: "docs", path: "docs" };
+
+    expect(isFileNode(value)).toBe(false);
+  });
+
+  it("children の要素が FileNode でないとき false を返す", () => {
+    const value: unknown = {
+      children: [{ name: "x.md", path: 1 }],
+      name: "docs",
+      path: "docs",
+    };
+
+    expect(isFileNode(value)).toBe(false);
+  });
+
+  it.each([
+    { input: null, label: "null" },
+    { input: undefined, label: "undefined" },
+    { input: "x", label: "string" },
+    { input: 1, label: "number" },
+    { input: true, label: "boolean" },
+  ])("$label のとき false を返す", ({ input }) => {
+    expect(isFileNode(input)).toBe(false);
+  });
+});
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(isFilesResponse, () => {
+  it("files が FileNode 配列のとき true を返す", () => {
+    const value: unknown = { files: [{ name: "a.md", path: "a.md" }] };
+
+    expect(isFilesResponse(value)).toBe(true);
+  });
+
+  it("files が空配列のとき true を返す", () => {
+    const value: unknown = { files: [] };
+
+    expect(isFilesResponse(value)).toBe(true);
+  });
+
+  it("files が配列でないとき false を返す", () => {
+    const value: unknown = { files: "x" };
+
+    expect(isFilesResponse(value)).toBe(false);
+  });
+
+  it("files プロパティが欠落しているとき false を返す", () => {
+    const value: unknown = {};
+
+    expect(isFilesResponse(value)).toBe(false);
+  });
+
+  it("files の要素が FileNode でないとき false を返す", () => {
+    const value: unknown = { files: [{ path: 1 }] };
+
+    expect(isFilesResponse(value)).toBe(false);
+  });
+});
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(isFileChangedPayload, () => {
+  it("path が string のとき true を返す", () => {
+    const value: unknown = { path: "a.md" };
+
+    expect(isFileChangedPayload(value)).toBe(true);
+  });
+
+  it("path が string でないとき false を返す", () => {
+    const value: unknown = { path: 123 };
+
+    expect(isFileChangedPayload(value)).toBe(false);
+  });
+
+  it("path プロパティが欠落しているとき false を返す", () => {
+    const value: unknown = {};
+
+    expect(isFileChangedPayload(value)).toBe(false);
+  });
+});
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(isTreeChangedPayload, () => {
+  it("files が FileNode 配列のとき true を返す", () => {
+    const value: unknown = { files: [{ name: "a.md", path: "a.md" }] };
+
+    expect(isTreeChangedPayload(value)).toBe(true);
+  });
+
+  it("files が配列でないとき false を返す", () => {
+    const value: unknown = { files: "x" };
+
+    expect(isTreeChangedPayload(value)).toBe(false);
+  });
+
+  it("files の要素が FileNode でないとき false を返す", () => {
+    const value: unknown = { files: [{ name: "x", path: 1 }] };
+
+    expect(isTreeChangedPayload(value)).toBe(false);
+  });
+});

--- a/tests/test-utils-event-source-mock.test.ts
+++ b/tests/test-utils-event-source-mock.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { EventSourceMock, installEventSourceMock } from "./test-utils";
+
+// 再発防止: app-header / app-responsive で重複していた no-op EventSource 実装を
+// `tests/test-utils.ts` に集約。新規テストが独自に EventSource を再実装しないよう、
+// helper の契約をここで固定する。過去の architect-review
+// (ARCH-NEW-tests-event-source-mock-dup) を参照。
+describe("EventSourceMock", () => {
+  it("EventSource interface を実装している", () => {
+    const es = new EventSourceMock("/api/watch");
+
+    expect(es.url).toBe("/api/watch");
+    expect(es.readyState).toBe(0);
+    expect(typeof es.addEventListener).toBe("function");
+    expect(typeof es.removeEventListener).toBe("function");
+    expect(typeof es.dispatchEvent).toBe("function");
+    expect(typeof es.close).toBe("function");
+  });
+
+  it("URL オブジェクトを受け取った場合は文字列化する", () => {
+    const es = new EventSourceMock(new URL("http://localhost/api/watch"));
+
+    expect(es.url).toBe("http://localhost/api/watch");
+  });
+});
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(installEventSourceMock, () => {
+  it("globalThis.EventSource を EventSourceMock に差し替える", () => {
+    const restore = installEventSourceMock();
+
+    try {
+      expect(globalThis.EventSource).toBe(EventSourceMock);
+    } finally {
+      restore();
+    }
+  });
+
+  it("restore 関数で元の実装に戻せる", () => {
+    const original = globalThis.EventSource;
+    const restore = installEventSourceMock();
+
+    restore();
+
+    expect(globalThis.EventSource).toBe(original);
+  });
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -2,6 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import type { ApiErrorResponse } from "@shared/errors";
+import { isApiErrorResponse } from "@shared/errors";
+import type { FilesResponse } from "@shared/types";
+import { isFilesResponse } from "@shared/types";
+
 export const createTmpDir = () =>
   fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "specv-test-")));
 
@@ -31,3 +36,66 @@ export const withTmpDir = async (
 };
 
 export { setTimeout as delay } from "node:timers/promises";
+
+// API レスポンスを SSOT 型 (`@shared/{types,errors}.ts`) に narrow する asserts ヘルパー。
+// 各テストファイルで `asserts value is FilesResponse` / `asserts value is ApiErrorResponse`
+// の戻り型を文字列レベルで再宣言しないよう、共有ヘルパーとして集約する。
+// 過去の architect-review (ARCH-NEW-tests-api-asserts-helper-dup /
+// ARCH-NEW-tests-api-asserts-shape-rehardcoded) を参照。
+export function expectFilesResponse(
+  value: unknown
+): asserts value is FilesResponse {
+  expect(isFilesResponse(value)).toBe(true);
+}
+
+export function expectApiErrorResponse(
+  value: unknown
+): asserts value is ApiErrorResponse {
+  expect(isApiErrorResponse(value)).toBe(true);
+}
+
+// jsdom 環境向けの no-op `EventSource` 実装。
+// `useWatch` が `new EventSource(...)` する経路でレンダリングが落ちないようにするためだけのもので、
+// 実際の SSE 動作はテストしない。SSE 振る舞いをテストする側は `tests/use-watch.test.ts` の
+// `MockEventSource`（dispatch/dispatchRaw 付き）を使う。
+export class EventSourceMock implements EventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSED = 2;
+  readonly url: string;
+  readonly withCredentials = false;
+  readonly readyState = 0;
+  onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+  onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
+  onopen: ((this: EventSource, ev: Event) => unknown) | null = null;
+
+  constructor(url: string | URL, _eventSourceInitDict?: EventSourceInit) {
+    this.url = typeof url === "string" ? url : url.toString();
+  }
+
+  // eslint-disable-next-line class-methods-use-this, no-empty-function
+  addEventListener() {}
+  // eslint-disable-next-line class-methods-use-this, no-empty-function
+  close() {}
+  // eslint-disable-next-line class-methods-use-this, no-empty-function
+  removeEventListener() {}
+  // eslint-disable-next-line class-methods-use-this
+  dispatchEvent(_event: Event): boolean {
+    return false;
+  }
+}
+
+// `globalThis.EventSource` を no-op `EventSourceMock` に差し替え、
+// 元の実装を復元するクリーンアップ関数を返す。
+// jsdom 環境では `EventSource` が `globalThis` に定義済みのため、
+// 復元はそのまま再代入すれば足りる。
+export const installEventSourceMock = (): (() => void) => {
+  const original = globalThis.EventSource;
+  globalThis.EventSource = EventSourceMock;
+  return () => {
+    globalThis.EventSource = original;
+  };
+};

--- a/tests/use-is-mobile.test.ts
+++ b/tests/use-is-mobile.test.ts
@@ -17,7 +17,7 @@ function createMockMatchMedia(matches: boolean) {
       }
     },
   };
-  window.matchMedia = vi.fn().mockReturnValue(mql) as typeof window.matchMedia;
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue(mql));
   return {
     mql,
     trigger: (newMatches: boolean) => {
@@ -32,6 +32,7 @@ function createMockMatchMedia(matches: boolean) {
 describe("hook: useIsMobile", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("デスクトップ幅 → false を返す", () => {

--- a/tests/use-scroll-restore.test.ts
+++ b/tests/use-scroll-restore.test.ts
@@ -1,38 +1,39 @@
 // @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
+import type React from "react";
 
 import { useScrollRestore } from "@/hooks/use-scroll-restore";
 
+const createScrollRef = (
+  scrollTop: number
+): React.RefObject<HTMLDivElement | null> => {
+  const div = document.createElement("div");
+  div.scrollTop = scrollTop;
+  return { current: div };
+};
+
 describe("hook: useScrollRestore", () => {
   it("selectedPath 変更時 → scrollTop = 0", () => {
-    const scrollRef = { current: { scrollTop: 150 } };
+    const scrollRef = createScrollRef(150);
 
     const { rerender } = renderHook(
-      ({ selectedPath }) =>
-        useScrollRestore(
-          scrollRef as unknown as React.RefObject<HTMLDivElement>,
-          selectedPath
-        ),
+      ({ selectedPath }) => useScrollRestore(scrollRef, selectedPath),
       { initialProps: { selectedPath: "a.md" } }
     );
 
     rerender({ selectedPath: "b.md" });
-    expect(scrollRef.current.scrollTop).toBe(0);
+    expect(scrollRef.current?.scrollTop).toBe(0);
   });
 
   it("同一パスの再レンダリング → scrollTop が変更されない", () => {
-    const scrollRef = { current: { scrollTop: 200 } };
+    const scrollRef = createScrollRef(200);
 
     const { rerender } = renderHook(
-      ({ selectedPath }) =>
-        useScrollRestore(
-          scrollRef as unknown as React.RefObject<HTMLDivElement>,
-          selectedPath
-        ),
+      ({ selectedPath }) => useScrollRestore(scrollRef, selectedPath),
       { initialProps: { selectedPath: "a.md" } }
     );
 
     rerender({ selectedPath: "a.md" });
-    expect(scrollRef.current.scrollTop).toBe(200);
+    expect(scrollRef.current?.scrollTop).toBe(200);
   });
 });

--- a/tests/use-theme.test.tsx
+++ b/tests/use-theme.test.tsx
@@ -35,9 +35,7 @@ function setupMatchMedia(matches: boolean) {
       // 同上
     },
   };
-  window.matchMedia = vi
-    .fn()
-    .mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue(mql));
 }
 
 const wrapper = ({ children }: { children: ReactNode }) => (
@@ -147,13 +145,22 @@ describe(ThemeProvider, () => {
     expect(storage.setItem).toHaveBeenCalledWith(STORAGE_KEY, "dark");
   });
 
-  it("localStorage に予期しない文字列があってもキャストしてそのまま使う", () => {
+  it('localStorage が "garbage" + matchMedia 一致のとき初期 theme が "dark" になる', () => {
+    setupStorage({ [STORAGE_KEY]: "garbage" });
+    setupMatchMedia(true);
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it('localStorage が "garbage" + matchMedia 不一致のとき初期 theme が "light" になる', () => {
     setupStorage({ [STORAGE_KEY]: "garbage" });
     setupMatchMedia(false);
 
     const { result } = renderHook(() => useTheme(), { wrapper });
 
-    expect(result.current.theme).toBe("garbage");
+    expect(result.current.theme).toBe("light");
   });
 });
 

--- a/tests/use-watch.test.ts
+++ b/tests/use-watch.test.ts
@@ -37,6 +37,13 @@ class MockEventSource {
     }
   }
 
+  dispatchRaw(type: string, raw: string) {
+    const cbs = this.listeners.get(type) ?? [];
+    for (const cb of cbs) {
+      cb({ data: raw });
+    }
+  }
+
   static get last(): MockEventSource {
     const inst = MockEventSource.instances.at(-1);
     if (!inst) {
@@ -203,5 +210,61 @@ describe(useWatch, () => {
       expect(logError).toHaveBeenCalled();
     });
     expect(setContent).not.toHaveBeenCalled();
+  });
+
+  it("file-changed の e.data が不正 JSON 文字列のとき副作用が起きない", () => {
+    const setContent = vi.fn();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    renderHook(() => useWatch("docs/guide.md", setContent, vi.fn(), vi.fn()));
+    act(() => {
+      MockEventSource.last.dispatchRaw("file-changed", "{not-json");
+    });
+
+    expect(setContent).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("tree-changed の e.data が不正 JSON 文字列のとき副作用が起きない", () => {
+    const setFiles = vi.fn();
+    const setSelectedPath = vi.fn();
+
+    renderHook(() =>
+      useWatch("docs/guide.md", vi.fn(), setFiles, setSelectedPath)
+    );
+    act(() => {
+      MockEventSource.last.dispatchRaw("tree-changed", "{not-json");
+    });
+
+    expect(setFiles).not.toHaveBeenCalled();
+    expect(setSelectedPath).not.toHaveBeenCalled();
+  });
+
+  it("file-changed の payload shape が不正なとき副作用が起きない", () => {
+    const setContent = vi.fn();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    renderHook(() => useWatch("docs/guide.md", setContent, vi.fn(), vi.fn()));
+    act(() => {
+      MockEventSource.last.dispatch("file-changed", { path: 123 });
+    });
+
+    expect(setContent).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("tree-changed の payload shape が不正なとき副作用が起きない", () => {
+    const setFiles = vi.fn();
+    const setSelectedPath = vi.fn();
+
+    renderHook(() =>
+      useWatch("docs/guide.md", vi.fn(), setFiles, setSelectedPath)
+    );
+    act(() => {
+      MockEventSource.last.dispatch("tree-changed", { files: "x" });
+    });
+
+    expect(setFiles).not.toHaveBeenCalled();
+    expect(setSelectedPath).not.toHaveBeenCalled();
   });
 });

--- a/tests/watch-api.test.ts
+++ b/tests/watch-api.test.ts
@@ -70,8 +70,10 @@ const setupWatchApp = (tmpDir: string) => {
 
 const requestWatch = async (app: ReturnType<typeof createApiRouter>) => {
   const res = await app.request("/api/watch");
-  expect(res.body).toBeTruthy();
-  return res.body as ReadableStream<Uint8Array>;
+  if (!res.body) {
+    throw new Error("res.body is null");
+  }
+  return res.body;
 };
 
 describe("gET /api/watch", () => {

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -15,6 +15,24 @@ const waitForEvent = async (
   });
 };
 
+// `vi.spyOn(fs, "watch")` の mock.calls から第 3 引数 (listener) を取り出すヘルパー。
+// fs.watch は overload が多く mock.calls の型が union 化されるため、
+// (event, filename) => void 形に narrow する unsafe-type-assertion が必要。
+// 同じ cast + eslint-disable コメントが複数 it ブロックで重複するのを防ぐため
+// 共有ヘルパーに集約する（architect-review: ARCH-NEW-watcher-test-callback-cast-dup）。
+// 引数は `watchSpy.mock.calls` を直接受け取る形にすることで `vi.spyOn` の戻り値型に依存しない。
+const captureWatchCallback = (
+  calls: readonly (readonly unknown[])[]
+): ((event: string, filename: string | null) => void) => {
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- vi.spyOn(fs, "watch") の overload 解決上 callback の型を復元する必要がある
+  const args = calls[0] as unknown as readonly [
+    unknown,
+    unknown,
+    (event: string, filename: string | null) => void,
+  ];
+  return args[2];
+};
+
 describe("server: createWatcher", () => {
   it(".md ファイルの変更を検知する", async () => {
     await withTmpDir(async (tmpDir) => {
@@ -220,10 +238,7 @@ describe("server: createWatcher (mocked fs.watch)", () => {
       const { close } = createWatcher(tmpDir, cb);
 
       try {
-        const captured = watchSpy.mock.calls[0]?.[2] as (
-          event: string,
-          filename: string | null
-        ) => void;
+        const captured = captureWatchCallback(watchSpy.mock.calls);
         captured("change", null);
 
         await delay(500);
@@ -241,10 +256,7 @@ describe("server: createWatcher (mocked fs.watch)", () => {
       const { close } = createWatcher(tmpDir, cb);
 
       try {
-        const captured = watchSpy.mock.calls[0]?.[2] as (
-          event: string,
-          filename: string | null
-        ) => void;
+        const captured = captureWatchCallback(watchSpy.mock.calls);
         captured("change", "../external.md");
 
         await delay(500);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,14 +8,13 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
-    "baseUrl": ".",
+    "types": ["vitest/globals", "node"],
     "paths": {
       "@/*": ["./src/client/*"],
       "@server/*": ["./src/server/*"],
       "@shared/*": ["./src/shared/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary

## 概要

issue #126（Vite+ の type-aware lint 有効化）の段階導入として、`typescript/no-unsafe-*` 系 4 ルールの違反を解消する。型安全性の中核を担うルール群。

## 親 issue

#126

## 対象ルール

| ルール | 想定件数 | 内容 |
|---|---|---|
| `typescript/no-unsafe-type-assertion` | 20 | `as Foo` 形式の型 narrowing |
| `typescript/no-unsafe-member-access` | 9 | `any` 型へのプロパティアクセス |
| `typescript/no-unsafe-assignment` | 5 | `any` 型からの代入 |
| `typescript/no-unsafe-argument` | 4 | `any` 型を引数として渡している |

合計 38 件（PR #125 時点の計測）。本 issue で **最大件数の sub issue**。

## 典型パターン

```ts
// ❌ NG: as による型 narrowing
const config = data as Config;

// ✅ OK: 型ガード関数で narrowing
function isConfig(value: unknown): value is Config { ... }
if (isConfig(data)) { ... }

// ✅ OK: zod / valibot 等のスキーマ検証
const config = ConfigSchema.parse(data);

// ❌ NG: any 型へのプロパティアクセス
const value: any = ...;
value.foo;  // no-unsafe-member-access

// ✅ OK: unknown + 型ガード
const value: unknown = ...;
if (typeof value === "object" && value !== null && "foo" in value) { ... }
```

## 進め方

1. ローカルで `lint.options.typeAware: true` / `typeCheck: true` を一時的に有効にして違反箇所を列挙
2. ファイル/モジュール単位でグループ化して 1 PR ずつ分けるか、まとめて 1 PR で潰すかを issue 着手時に判断
3. `as` を型ガード or スキーマ検証に置換
4. `any` の発生源を特定し、`unknown` + narrowing or 適切な型注釈に置換
5. 修正後、type-aware を再度 off に戻す（本 PR では有効化しない）

## 受け入れ基準

- [ ] type-aware を有効化しても `typescript/no-unsafe-*` 4 ルールがすべて 0 件
- [ ] `nr test` / `nr test:e2e` が通る
- [ ] `nr check` が通る
- [ ] `as` を残す必要がある場合は eslint-disable コメントで個別に理由を明記

## メモ

- ルール自体は **off にしない**（issue #126 のゴールは「全ルール on のまま typeAware: true」）
- 件数が多く影響範囲が広いので、PR 単位を粗くせず必要に応じて sub-sub issue で分割してもよい

## Execution Report

Workflow `default` completed successfully.

Closes #130