### PR TITLE
takt: issue-81 SRP に基づくリファクタリング

### DIFF
--- a/src/client/components/file-tree-node.tsx
+++ b/src/client/components/file-tree-node.tsx
@@ -1,0 +1,98 @@
+import type { FileNode } from "@shared/types";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Folder,
+  FolderOpen,
+} from "lucide-react";
+import { useCallback } from "react";
+
+import { TreeItem, TreeLeaf } from "@/components/ui/tree";
+
+interface FileTreeNodeProps {
+  node: FileNode;
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  forceExpand: boolean;
+  expandedPaths: Set<string>;
+  onExpand: (dirPath: string) => void;
+  onCollapse: (dirPath: string) => void;
+}
+
+export const FileTreeNode = ({
+  node,
+  selectedPath,
+  onSelect,
+  forceExpand,
+  expandedPaths,
+  onExpand,
+  onCollapse,
+}: FileTreeNodeProps) => {
+  const isDir = node.children !== undefined;
+  const isOpen = forceExpand || expandedPaths.has(node.path);
+
+  const handleToggleExpand = useCallback(() => {
+    if (isOpen && !forceExpand) {
+      onCollapse(node.path);
+    } else {
+      onExpand(node.path);
+    }
+  }, [isOpen, forceExpand, onCollapse, onExpand, node.path]);
+
+  const handleSelect = useCallback(() => {
+    onSelect(node.path);
+  }, [onSelect, node.path]);
+
+  if (isDir) {
+    return (
+      <TreeItem
+        expanded={isOpen}
+        icon={
+          <>
+            {isOpen ? (
+              <ChevronDown
+                size={14}
+                className="shrink-0 text-muted-foreground"
+              />
+            ) : (
+              <ChevronRight
+                size={14}
+                className="shrink-0 text-muted-foreground"
+              />
+            )}
+            {isOpen ? (
+              <FolderOpen size={14} className="shrink-0 text-amber-500" />
+            ) : (
+              <Folder size={14} className="shrink-0 text-amber-500" />
+            )}
+          </>
+        }
+        name={node.name}
+        onToggle={handleToggleExpand}
+      >
+        {node.children?.map((child) => (
+          <FileTreeNode
+            key={child.path}
+            node={child}
+            selectedPath={selectedPath}
+            onSelect={onSelect}
+            forceExpand={forceExpand}
+            expandedPaths={expandedPaths}
+            onExpand={onExpand}
+            onCollapse={onCollapse}
+          />
+        ))}
+      </TreeItem>
+    );
+  }
+
+  return (
+    <TreeLeaf
+      icon={<FileText size={14} className="shrink-0 text-blue-500" />}
+      name={node.name}
+      onSelect={handleSelect}
+      selected={node.path === selectedPath}
+    />
+  );
+};

--- a/src/client/components/file-tree.tsx
+++ b/src/client/components/file-tree.tsx
@@ -1,132 +1,23 @@
 import type { FileNode } from "@shared/types";
-import {
-  ChevronDown,
-  ChevronRight,
-  FileText,
-  Folder,
-  FolderOpen,
-  Search,
-} from "lucide-react";
+import { Search } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { FileTreeNode } from "@/components/file-tree-node";
 import {
   InputGroup,
   InputGroupAddon,
   InputGroupInput,
 } from "@/components/ui/input-group";
 import { Kbd } from "@/components/ui/kbd";
-import { Tree, TreeItem, TreeLeaf } from "@/components/ui/tree";
+import { Tree } from "@/components/ui/tree";
 import { computeAutoExpandPaths, findNode } from "@/lib/auto-expand";
+import { filterTree } from "@/lib/file-tree-filter";
 
 interface FileTreeProps {
   files: FileNode[];
   selectedPath: string | null;
   onSelect: (path: string) => void;
 }
-
-const filterTree = (nodes: FileNode[], query: string): FileNode[] => {
-  const lower = query.toLowerCase();
-  const result: FileNode[] = [];
-  for (const node of nodes) {
-    if (node.children !== undefined) {
-      const filtered = filterTree(node.children, query);
-      if (filtered.length > 0) {
-        result.push({ ...node, children: filtered });
-      }
-    } else if (
-      node.name.toLowerCase().includes(lower) ||
-      node.path.toLowerCase().includes(lower)
-    ) {
-      result.push(node);
-    }
-  }
-  return result;
-};
-
-const FileTreeNode = ({
-  node,
-  selectedPath,
-  onSelect,
-  forceExpand,
-  expandedPaths,
-  onExpand,
-  onCollapse,
-}: {
-  node: FileNode;
-  selectedPath: string | null;
-  onSelect: (path: string) => void;
-  forceExpand: boolean;
-  expandedPaths: Set<string>;
-  onExpand: (dirPath: string) => void;
-  onCollapse: (dirPath: string) => void;
-}) => {
-  const isDir = node.children !== undefined;
-  const isOpen = forceExpand || expandedPaths.has(node.path);
-
-  const handleToggleExpand = useCallback(() => {
-    if (isOpen && !forceExpand) {
-      onCollapse(node.path);
-    } else {
-      onExpand(node.path);
-    }
-  }, [isOpen, forceExpand, onCollapse, onExpand, node.path]);
-
-  const handleSelect = useCallback(() => {
-    onSelect(node.path);
-  }, [onSelect, node.path]);
-
-  if (isDir) {
-    return (
-      <TreeItem
-        expanded={isOpen}
-        icon={
-          <>
-            {isOpen ? (
-              <ChevronDown
-                size={14}
-                className="shrink-0 text-muted-foreground"
-              />
-            ) : (
-              <ChevronRight
-                size={14}
-                className="shrink-0 text-muted-foreground"
-              />
-            )}
-            {isOpen ? (
-              <FolderOpen size={14} className="shrink-0 text-amber-500" />
-            ) : (
-              <Folder size={14} className="shrink-0 text-amber-500" />
-            )}
-          </>
-        }
-        name={node.name}
-        onToggle={handleToggleExpand}
-      >
-        {node.children?.map((child) => (
-          <FileTreeNode
-            key={child.path}
-            node={child}
-            selectedPath={selectedPath}
-            onSelect={onSelect}
-            forceExpand={forceExpand}
-            expandedPaths={expandedPaths}
-            onExpand={onExpand}
-            onCollapse={onCollapse}
-          />
-        ))}
-      </TreeItem>
-    );
-  }
-
-  return (
-    <TreeLeaf
-      icon={<FileText size={14} className="shrink-0 text-blue-500" />}
-      name={node.name}
-      onSelect={handleSelect}
-      selected={node.path === selectedPath}
-    />
-  );
-};
 
 export const FileTree = ({ files, selectedPath, onSelect }: FileTreeProps) => {
   const [query, setQuery] = useState("");

--- a/src/client/lib/file-tree-filter.ts
+++ b/src/client/lib/file-tree-filter.ts
@@ -1,0 +1,20 @@
+import type { FileNode } from "@shared/types";
+
+export const filterTree = (nodes: FileNode[], query: string): FileNode[] => {
+  const lower = query.toLowerCase();
+  const result: FileNode[] = [];
+  for (const node of nodes) {
+    if (node.children !== undefined) {
+      const filtered = filterTree(node.children, query);
+      if (filtered.length > 0) {
+        result.push({ ...node, children: filtered });
+      }
+    } else if (
+      node.name.toLowerCase().includes(lower) ||
+      node.path.toLowerCase().includes(lower)
+    ) {
+      result.push(node);
+    }
+  }
+  return result;
+};

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,199 +1,28 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-
-import { AppError, type ApiErrorResponse } from "@shared/errors";
-import type {
-  FileChangedPayload,
-  FilesResponse,
-  TreeChangedPayload,
-  WatchEventName,
-} from "@shared/types";
 import { Hono } from "hono";
 
-import { scanMarkdownFiles } from "./files";
-import { validateImagePath, validatePath } from "./security";
+import { registerFileRoutes } from "./api/file-routes";
+import { createSseBroadcaster } from "./api/sse-broadcaster";
+import { registerWatchRoutes, type WatcherFactory } from "./api/watch-routes";
 import { createWatcher as defaultCreateWatcher } from "./watcher";
-import type { WatchCallback } from "./watcher";
-
-const buildAppErrorResponse = (error: AppError): ApiErrorResponse => ({
-  code: error.code,
-  error: error.message,
-});
-
-const IMAGE_CONTENT_TYPES: Record<string, string> = {
-  ".gif": "image/gif",
-  ".jpeg": "image/jpeg",
-  ".jpg": "image/jpeg",
-  ".png": "image/png",
-  ".svg": "image/svg+xml",
-  ".webp": "image/webp",
-};
-
-const readFile = (filePath: string, baseDir: string): Promise<string> => {
-  const resolvedPath = validatePath(filePath, baseDir);
-  return fs.readFile(resolvedPath, "utf8");
-};
-
-const readImage = async (
-  filePath: string,
-  baseDir: string
-): Promise<{ contentType: string; data: Buffer }> => {
-  const resolvedPath = validateImagePath(filePath, baseDir);
-  const ext = path.extname(resolvedPath).toLowerCase();
-  const contentType = IMAGE_CONTENT_TYPES[ext] ?? "application/octet-stream";
-  const data = await fs.readFile(resolvedPath);
-  return { contentType, data };
-};
-
-type WatcherFactory = (
-  baseDir: string,
-  onEvent: WatchCallback
-) => { close: () => void };
 
 interface ApiRouterOptions {
   createWatcher?: WatcherFactory;
 }
-
-const TREE_DEBOUNCE_MS = 300;
-
-interface SSEMessage {
-  data: string;
-  event: WatchEventName;
-}
-type SSEListener = (msg: SSEMessage) => void;
-
-const setupWatcher = (
-  baseDir: string,
-  factory: WatcherFactory,
-  broadcast: (msg: SSEMessage) => void
-) => {
-  let treeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-
-  factory(baseDir, (event) => {
-    if (event.type === "change") {
-      broadcast({
-        data: JSON.stringify({
-          path: event.path,
-        } satisfies FileChangedPayload),
-        event: "file-changed",
-      });
-    } else {
-      if (treeDebounceTimer !== null) {
-        clearTimeout(treeDebounceTimer);
-      }
-      treeDebounceTimer = setTimeout(() => {
-        void (async () => {
-          try {
-            const files = await scanMarkdownFiles(baseDir);
-            broadcast({
-              data: JSON.stringify({ files } satisfies TreeChangedPayload),
-              event: "tree-changed",
-            });
-          } catch {
-            // Scan failure is non-fatal
-          }
-        })();
-      }, TREE_DEBOUNCE_MS);
-    }
-  });
-};
 
 export const createApiRouter = (
   baseDir: string,
   options?: ApiRouterOptions
 ): Hono => {
   const api = new Hono();
-  const sseListeners = new Set<SSEListener>();
-  const encoder = new TextEncoder();
+  const broadcaster = createSseBroadcaster();
 
-  const broadcast = (msg: SSEMessage) => {
-    for (const listener of sseListeners) {
-      listener(msg);
-    }
-  };
-
-  setupWatcher(
+  registerFileRoutes(api, baseDir);
+  registerWatchRoutes(
+    api,
     baseDir,
     options?.createWatcher ?? defaultCreateWatcher,
-    broadcast
+    broadcaster
   );
-
-  api.get("/api/files", async (c) => {
-    try {
-      const files = await scanMarkdownFiles(baseDir);
-      return c.json<FilesResponse>({ files });
-    } catch {
-      return c.json<ApiErrorResponse>({ error: "Failed to scan files" }, 500);
-    }
-  });
-
-  api.get("/api/file", async (c) => {
-    const filePath = c.req.query("path");
-    if (filePath === undefined || filePath === "") {
-      return c.json<ApiErrorResponse>(
-        { error: "path query parameter is required" },
-        400
-      );
-    }
-
-    try {
-      const content = await readFile(filePath, baseDir);
-      return c.text(content);
-    } catch (error) {
-      if (error instanceof AppError) {
-        return c.json<ApiErrorResponse>(buildAppErrorResponse(error), 400);
-      }
-      return c.json<ApiErrorResponse>({ error: "File not found" }, 404);
-    }
-  });
-
-  api.get("/api/image", async (c) => {
-    const filePath = c.req.query("path");
-    if (filePath === undefined || filePath === "") {
-      return c.json<ApiErrorResponse>(
-        { error: "path query parameter is required" },
-        400
-      );
-    }
-
-    try {
-      const { contentType, data } = await readImage(filePath, baseDir);
-      return c.body(new Uint8Array(data), 200, { "Content-Type": contentType });
-    } catch (error) {
-      if (error instanceof AppError) {
-        return c.json<ApiErrorResponse>(buildAppErrorResponse(error), 400);
-      }
-      return c.json<ApiErrorResponse>({ error: "Image not found" }, 404);
-    }
-  });
-
-  api.get("/api/watch", (_c) => {
-    let listener: SSEListener | null = null;
-
-    const stream = new ReadableStream({
-      cancel() {
-        if (listener !== null) {
-          sseListeners.delete(listener);
-        }
-      },
-      start(controller) {
-        listener = (msg) => {
-          controller.enqueue(
-            encoder.encode(`event: ${msg.event}\ndata: ${msg.data}\n\n`)
-          );
-        };
-        sseListeners.add(listener);
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-        "Content-Type": "text/event-stream",
-      },
-    });
-  });
 
   return api;
 };

--- a/src/server/api/file-routes.ts
+++ b/src/server/api/file-routes.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { AppError, type ApiErrorResponse } from "@shared/errors";
+import type { FilesResponse } from "@shared/types";
+import type { Hono } from "hono";
+
+import { scanMarkdownFiles } from "../files";
+import { validateImagePath, validatePath } from "../security";
+
+const buildAppErrorResponse = (error: AppError): ApiErrorResponse => ({
+  code: error.code,
+  error: error.message,
+});
+
+const IMAGE_CONTENT_TYPES: Record<string, string> = {
+  ".gif": "image/gif",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+};
+
+const readFile = (filePath: string, baseDir: string): Promise<string> => {
+  const resolvedPath = validatePath(filePath, baseDir);
+  return fs.readFile(resolvedPath, "utf8");
+};
+
+const readImage = async (
+  filePath: string,
+  baseDir: string
+): Promise<{ contentType: string; data: Buffer }> => {
+  const resolvedPath = validateImagePath(filePath, baseDir);
+  const ext = path.extname(resolvedPath).toLowerCase();
+  const contentType = IMAGE_CONTENT_TYPES[ext] ?? "application/octet-stream";
+  const data = await fs.readFile(resolvedPath);
+  return { contentType, data };
+};
+
+export const registerFileRoutes = (api: Hono, baseDir: string): void => {
+  api.get("/api/files", async (c) => {
+    try {
+      const files = await scanMarkdownFiles(baseDir);
+      return c.json<FilesResponse>({ files });
+    } catch {
+      return c.json<ApiErrorResponse>({ error: "Failed to scan files" }, 500);
+    }
+  });
+
+  api.get("/api/file", async (c) => {
+    const filePath = c.req.query("path");
+    if (filePath === undefined || filePath === "") {
+      return c.json<ApiErrorResponse>(
+        { error: "path query parameter is required" },
+        400
+      );
+    }
+
+    try {
+      const content = await readFile(filePath, baseDir);
+      return c.text(content);
+    } catch (error) {
+      if (error instanceof AppError) {
+        return c.json<ApiErrorResponse>(buildAppErrorResponse(error), 400);
+      }
+      return c.json<ApiErrorResponse>({ error: "File not found" }, 404);
+    }
+  });
+
+  api.get("/api/image", async (c) => {
+    const filePath = c.req.query("path");
+    if (filePath === undefined || filePath === "") {
+      return c.json<ApiErrorResponse>(
+        { error: "path query parameter is required" },
+        400
+      );
+    }
+
+    try {
+      const { contentType, data } = await readImage(filePath, baseDir);
+      return c.body(new Uint8Array(data), 200, { "Content-Type": contentType });
+    } catch (error) {
+      if (error instanceof AppError) {
+        return c.json<ApiErrorResponse>(buildAppErrorResponse(error), 400);
+      }
+      return c.json<ApiErrorResponse>({ error: "Image not found" }, 404);
+    }
+  });
+};

--- a/src/server/api/lifecycle-routes.ts
+++ b/src/server/api/lifecycle-routes.ts
@@ -1,0 +1,43 @@
+import type { Hono } from "hono";
+
+const DISCONNECT_GRACE_MS = 2000;
+
+export const registerLifecycleRoutes = (
+  app: Hono,
+  onDisconnect: () => void
+): void => {
+  let connections = 0;
+  let graceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  app.get("/api/lifecycle", (_c) => {
+    connections += 1;
+    if (graceTimer !== null) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
+
+    const stream = new ReadableStream({
+      cancel() {
+        connections -= 1;
+        if (connections === 0) {
+          graceTimer = setTimeout(() => {
+            if (connections === 0) {
+              onDisconnect();
+            }
+          }, DISCONNECT_GRACE_MS);
+        }
+      },
+      start(controller) {
+        controller.enqueue("data: connected\n\n");
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "Content-Type": "text/event-stream",
+      },
+    });
+  });
+};

--- a/src/server/api/sse-broadcaster.ts
+++ b/src/server/api/sse-broadcaster.ts
@@ -1,0 +1,54 @@
+import type { WatchEventName } from "@shared/types";
+
+export interface SseMessage {
+  data: string;
+  event: WatchEventName;
+}
+
+type SseListener = (msg: SseMessage) => void;
+
+export interface SseBroadcaster {
+  attachSseStream: () => Response;
+  broadcast: (msg: SseMessage) => void;
+}
+
+export const createSseBroadcaster = (): SseBroadcaster => {
+  const listeners = new Set<SseListener>();
+  const encoder = new TextEncoder();
+
+  const broadcast = (msg: SseMessage) => {
+    for (const listener of listeners) {
+      listener(msg);
+    }
+  };
+
+  const attachSseStream = (): Response => {
+    let listener: SseListener | null = null;
+
+    const stream = new ReadableStream({
+      cancel() {
+        if (listener !== null) {
+          listeners.delete(listener);
+        }
+      },
+      start(controller) {
+        listener = (msg) => {
+          controller.enqueue(
+            encoder.encode(`event: ${msg.event}\ndata: ${msg.data}\n\n`)
+          );
+        };
+        listeners.add(listener);
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "Content-Type": "text/event-stream",
+      },
+    });
+  };
+
+  return { attachSseStream, broadcast };
+};

--- a/src/server/api/watch-routes.ts
+++ b/src/server/api/watch-routes.ts
@@ -1,0 +1,60 @@
+import type { FileChangedPayload, TreeChangedPayload } from "@shared/types";
+import type { Hono } from "hono";
+
+import { scanMarkdownFiles } from "../files";
+import type { WatchCallback } from "../watcher";
+import type { SseBroadcaster } from "./sse-broadcaster";
+
+export type WatcherFactory = (
+  baseDir: string,
+  onEvent: WatchCallback
+) => { close: () => void };
+
+const TREE_DEBOUNCE_MS = 300;
+
+const setupWatcher = (
+  baseDir: string,
+  factory: WatcherFactory,
+  broadcaster: SseBroadcaster
+) => {
+  let treeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  factory(baseDir, (event) => {
+    if (event.type === "change") {
+      broadcaster.broadcast({
+        data: JSON.stringify({
+          path: event.path,
+        } satisfies FileChangedPayload),
+        event: "file-changed",
+      });
+    } else {
+      if (treeDebounceTimer !== null) {
+        clearTimeout(treeDebounceTimer);
+      }
+      treeDebounceTimer = setTimeout(() => {
+        void (async () => {
+          try {
+            const files = await scanMarkdownFiles(baseDir);
+            broadcaster.broadcast({
+              data: JSON.stringify({ files } satisfies TreeChangedPayload),
+              event: "tree-changed",
+            });
+          } catch {
+            // Scan failure is non-fatal
+          }
+        })();
+      }, TREE_DEBOUNCE_MS);
+    }
+  });
+};
+
+export const registerWatchRoutes = (
+  api: Hono,
+  baseDir: string,
+  factory: WatcherFactory,
+  broadcaster: SseBroadcaster
+): void => {
+  setupWatcher(baseDir, factory, broadcaster);
+
+  api.get("/api/watch", (_c) => broadcaster.attachSseStream());
+};

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -11,6 +11,7 @@ import { program } from "commander";
 import { Hono } from "hono";
 
 import { createApiRouter } from "./api";
+import { registerLifecycleRoutes } from "./api/lifecycle-routes";
 import { getLocalIpAddress } from "./network";
 import { openInBrowser } from "./open-browser";
 import { displayQrCode } from "./qr-display";
@@ -35,45 +36,6 @@ const pkg = parsedPkg;
 
 const currentDir = import.meta.dirname;
 
-const DISCONNECT_GRACE_MS = 2000;
-
-const registerLifecycle = (app: Hono, onDisconnect: () => void) => {
-  let connections = 0;
-  let graceTimer: ReturnType<typeof setTimeout> | null = null;
-
-  app.get("/api/lifecycle", (_c) => {
-    connections += 1;
-    if (graceTimer !== null) {
-      clearTimeout(graceTimer);
-      graceTimer = null;
-    }
-
-    const stream = new ReadableStream({
-      cancel() {
-        connections -= 1;
-        if (connections === 0) {
-          graceTimer = setTimeout(() => {
-            if (connections === 0) {
-              onDisconnect();
-            }
-          }, DISCONNECT_GRACE_MS);
-        }
-      },
-      start(controller) {
-        controller.enqueue("data: connected\n\n");
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-        "Content-Type": "text/event-stream",
-      },
-    });
-  });
-};
-
 const serveClient = (app: Hono, clientDir: string) => {
   const indexHtmlPath = path.join(clientDir, "index.html");
   if (fs.existsSync(indexHtmlPath)) {
@@ -91,7 +53,7 @@ const createApp = (
   const app = new Hono();
 
   if (onDisconnect !== undefined) {
-    registerLifecycle(app, onDisconnect);
+    registerLifecycleRoutes(app, onDisconnect);
   }
   app.route("/", createApiRouter(baseDir));
   serveClient(app, clientDir);


### PR DESCRIPTION
## Summary

issue #81 の SRP リファクタ。振る舞い不変で責務肥大モジュールを分割した。

## Changes

### Server
- `src/server/api/file-routes.ts`: `/api/files` `/api/file` `/api/image` ハンドラ抽出 (`registerFileRoutes`)
- `src/server/api/watch-routes.ts`: `/api/watch` + watcher → SSE 翻訳抽出 (`registerWatchRoutes`)
- `src/server/api/sse-broadcaster.ts`: SSE listener registry を `createSseBroadcaster` ファクトリに抽出
- `src/server/api/lifecycle-routes.ts`: `/api/lifecycle` + `DISCONNECT_GRACE_MS` grace timer を `cli.ts` から抽出
- `src/server/api.ts`: 199 行 → 29 行（orchestrator のみ）
- `src/server/cli.ts`: 197 行 → 159 行

### Client
- `src/client/lib/file-tree-filter.ts`: `filterTree` 純関数を `auto-expand.ts` パターンに沿って抽出
- `src/client/components/file-tree-node.tsx`: `FileTreeNode` 再帰描画コンポーネントを抽出
- `src/client/components/file-tree.tsx`: 227 行 → 118 行（query state / 検索 UI のみ）

## Public API

不変。`createApiRouter` / `getNetworkConfig` / `FileTree` のシグネチャと import パスは変更なし。`/api/files` `/api/file` `/api/image` `/api/watch` `/api/lifecycle` の 5 ルートすべて保存。

## Verification

- `nr test`: ✅ 40 files / 335 passed / 1 skipped / 1 todo
- `nr check`: ✅ 165 files formatted、107 files lint clean
- `nr knip`: ✅ exit 0
- 公開 API import パス: tests 側の `@server/api` / `@server/cli` / `@/components/file-tree` 変更なし

Closes #81

🤖 Generated with [takt](https://github.com/nrslib/takt)