### PR TITLE
chore(takt): coder persona を Claude opus に固定

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -97,7 +97,7 @@ takt -i <issue 番号> --auto-pr --draft        # 完了後にドラフト PR �
 
 ## 構成
 
-- `.takt/config.yaml` — プロジェクト固有のオーバーライド（`draft_pr: true` のみ）
+- `.takt/config.yaml` — プロジェクト固有のオーバーライド（`draft_pr: true` と `persona_providers.coder` を Claude opus に固定）
 - `.takt/.gitignore` — runtime artifacts (`runs/`, `tasks/`, `tasks.yaml` など) を allowlist 方式で除外。ルート `.gitignore` への追加は不要
 
 ## 前提（グローバル設定）

--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -3,3 +3,11 @@
 
 # 自動 PR を作成する場合はドラフトとして作成（試運転段階の安全運用）
 draft_pr: true
+
+# coder persona を Claude opus に固定する。
+# global では coder のみ Codex に振っているが、specv では vp check / Vite+ の lint・format で
+# Codex がアボートするケースがあったため、プロジェクト単位で Claude opus に揃える。
+persona_providers:
+  coder:
+    provider: claude
+    model: opus


### PR DESCRIPTION
## Summary

- `.takt/config.yaml` の `persona_providers.coder` で coder を `claude/opus` に上書き
- `.claude/CLAUDE.md` の構成説明を更新

## Why

global の `persona_providers` では coder のみ Codex に振っているが、specv では vp check / Vite+ の lint・format で Codex がアボートするケースが発生（#141 の draft subworkflow で `ai-antipattern-fix` step が `Status not found ... no rule matched` で abort）。プロジェクト単位で coder を Claude opus に揃えて、draft step を安定して完走させる。

global 設定は触らない（CLAUDE.md ガイドライン: 一時回避は project 側で）。

## Test plan

- [x] `vp check --fix` ローカル pass
- [x] `pnpm knip` issue なし
- [ ] merge 後、issue #141 を builtin の default で再起動して draft step まで通ることを確認