### PR TITLE
[#141] issue-141-desaabaaga-sare-bura

### DIFF
--- a/src/client/app.tsx
+++ b/src/client/app.tsx
@@ -8,6 +8,7 @@ import { fetchFile, fetchFiles } from "./api";
 import { FileTree } from "./components/file-tree";
 import { Preview } from "./components/markdown/preview";
 import { QuickOpen } from "./components/quick-open";
+import { ServerDownBanner } from "./components/server-down-banner";
 import { Source } from "./components/source";
 import { ThemeToggle } from "./components/theme-toggle";
 import { Button } from "./components/ui/button";
@@ -22,8 +23,10 @@ import {
   useSidebar,
 } from "./components/ui/sidebar";
 import { useScrollRestore } from "./hooks/use-scroll-restore";
+import { type ServerStatus, useServerStatus } from "./hooks/use-server-status";
 import { useWatch } from "./hooks/use-watch";
 import { findFirstFile } from "./lib/auto-expand";
+import { isNetworkError } from "./lib/is-network-error";
 import { logError } from "./lib/logger";
 
 type ViewMode = "preview" | "source";
@@ -51,7 +54,8 @@ const renderContent = (
 
 const useLoadFiles = (
   setFiles: (f: FileNode[]) => void,
-  setSelectedPath: (p: string | null) => void
+  setSelectedPath: (p: string | null) => void,
+  onServerDown: () => void
 ) => {
   useEffect(() => {
     const load = async () => {
@@ -63,11 +67,14 @@ const useLoadFiles = (
           setSelectedPath(first);
         }
       } catch (error) {
+        if (isNetworkError(error)) {
+          onServerDown();
+        }
         logError("Failed to load files:", error);
       }
     };
     void load();
-  }, [setFiles, setSelectedPath]);
+  }, [setFiles, setSelectedPath, onServerDown]);
 };
 
 const useLoadContent = (
@@ -113,22 +120,29 @@ const useHotkeys = (
   });
 };
 
-const useLifecycle = () => {
-  useEffect(() => {
-    const es = new EventSource("/api/lifecycle");
-    return () => {
-      es.close();
-    };
+// SSE ライフサイクル監視に加え、初回 API のネットワークエラーも
+// 「サーバー停止」とみなして disconnected に倒す。停止状態は
+// リロードでのみ復帰させる（バナーのリロードボタンが復帰手段）。
+const useServerHealth = () => {
+  const sseStatus = useServerStatus();
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const markServerDown = useCallback(() => {
+    setLoadFailed(true);
   }, []);
+
+  const status: ServerStatus = loadFailed ? "disconnected" : sseStatus;
+
+  return { markServerDown, status };
 };
 
-const useContentState = () => {
+const useContentState = (onServerDown: () => void) => {
   const [files, setFiles] = useState<FileNode[]>([]);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [content, setContent] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  useLoadFiles(setFiles, setSelectedPath);
+  useLoadFiles(setFiles, setSelectedPath, onServerDown);
   useLoadContent(selectedPath, setContent);
   useWatch(selectedPath, setContent, setFiles, setSelectedPath);
   useScrollRestore(scrollRef, selectedPath);
@@ -136,7 +150,7 @@ const useContentState = () => {
   return { content, files, scrollRef, selectedPath, setSelectedPath };
 };
 
-const useAppState = () => {
+const useAppState = (onServerDown: () => void) => {
   const [viewMode, setViewMode] = useState<ViewMode>("preview");
   const [quickOpenVisible, setQuickOpenVisible] = useState(false);
 
@@ -144,13 +158,13 @@ const useAppState = () => {
 
   return {
     ...useAppHandlers(setViewMode, setQuickOpenVisible),
-    ...useContentState(),
+    ...useContentState(onServerDown),
     quickOpenVisible,
     viewMode,
   };
 };
 
-const AppContent = () => {
+const AppContent = ({ onServerDown }: { onServerDown: () => void }) => {
   const { isMobile, open, openMobile, toggleSidebar } = useSidebar();
   const isOpen = isMobile ? openMobile : open;
 
@@ -165,7 +179,7 @@ const AppContent = () => {
     selectedPath,
     setSelectedPath,
     viewMode,
-  } = useAppState();
+  } = useAppState(onServerDown);
 
   const handleSelect = useCallback(
     (path: string) => {
@@ -259,7 +273,7 @@ const AppContent = () => {
 };
 
 export const App = () => {
-  useLifecycle();
+  const { markServerDown, status } = useServerHealth();
 
   return (
     <SidebarProvider
@@ -268,7 +282,8 @@ export const App = () => {
         "--sidebar-width": `${String(SIDEBAR_DEFAULT_WIDTH)}px`,
       }}
     >
-      <AppContent />
+      <ServerDownBanner status={status} />
+      <AppContent onServerDown={markServerDown} />
     </SidebarProvider>
   );
 };

--- a/src/client/components/server-down-banner.tsx
+++ b/src/client/components/server-down-banner.tsx
@@ -1,0 +1,29 @@
+import type { ServerStatus } from "@/hooks/use-server-status";
+
+import { Button } from "./ui/button";
+
+const reloadPage = () => {
+  window.location.reload();
+};
+
+// サーバー停止 (SSE 切断 grace 経過 or 初回 API のネットワークエラー) を
+// 無言の白画面にせず明示し、リロードで復帰する手段を提供する。
+export const ServerDownBanner = ({ status }: { status: ServerStatus }) => {
+  if (status !== "disconnected") {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className="fixed inset-x-0 top-0 z-50 flex items-center justify-center gap-3 border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-sm text-destructive"
+    >
+      <span>
+        サーバーとの接続が切れました。サーバーが停止している可能性があります。
+      </span>
+      <Button variant="destructive" size="sm" onClick={reloadPage}>
+        再読み込み
+      </Button>
+    </div>
+  );
+};

--- a/src/client/hooks/use-server-status.ts
+++ b/src/client/hooks/use-server-status.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+export type ServerStatus = "connecting" | "connected" | "disconnected";
+
+// `/api/lifecycle` の SSE 接続でサーバー生存を監視する。
+// EventSource は切断時に自動再接続を試みるため、error → open で
+// connected へ復帰する（再接続の表現）。
+export const useServerStatus = (): ServerStatus => {
+  const [status, setStatus] = useState<ServerStatus>("connecting");
+
+  useEffect(() => {
+    const es = new EventSource("/api/lifecycle");
+    const handleOpen = () => {
+      setStatus("connected");
+    };
+    const handleError = () => {
+      setStatus("disconnected");
+    };
+    es.addEventListener("open", handleOpen);
+    es.addEventListener("error", handleError);
+    // close() で接続破棄するためリスナーの明示削除は不要。
+    return () => {
+      es.close();
+    };
+  }, []);
+
+  return status;
+};

--- a/src/client/lib/is-network-error.ts
+++ b/src/client/lib/is-network-error.ts
@@ -1,0 +1,5 @@
+// fetch() は到達不能・接続切断などネットワーク層の失敗時に TypeError を投げる。
+// HTTP エラー応答 (4xx/5xx) は Response として返るためここには到達しない。
+// この区別により「サーバー停止」と「通常の API エラー」を切り分ける。
+export const isNetworkError = (error: unknown): boolean =>
+  error instanceof TypeError;

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -11,6 +11,7 @@ import { program } from "commander";
 import { Hono } from "hono";
 
 import { createApiRouter } from "./api";
+import { registerLifecycle } from "./lifecycle";
 import { getLocalIpAddress } from "./network";
 import { openInBrowser } from "./open-browser";
 import { displayQrCode } from "./qr-display";
@@ -35,45 +36,6 @@ const pkg = parsedPkg;
 
 const currentDir = import.meta.dirname;
 
-const DISCONNECT_GRACE_MS = 2000;
-
-const registerLifecycle = (app: Hono, onDisconnect: () => void) => {
-  let connections = 0;
-  let graceTimer: ReturnType<typeof setTimeout> | null = null;
-
-  app.get("/api/lifecycle", (_c) => {
-    connections += 1;
-    if (graceTimer !== null) {
-      clearTimeout(graceTimer);
-      graceTimer = null;
-    }
-
-    const stream = new ReadableStream({
-      cancel() {
-        connections -= 1;
-        if (connections === 0) {
-          graceTimer = setTimeout(() => {
-            if (connections === 0) {
-              onDisconnect();
-            }
-          }, DISCONNECT_GRACE_MS);
-        }
-      },
-      start(controller) {
-        controller.enqueue("data: connected\n\n");
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-        "Content-Type": "text/event-stream",
-      },
-    });
-  });
-};
-
 const serveClient = (app: Hono, clientDir: string) => {
   const indexHtmlPath = path.join(clientDir, "index.html");
   if (fs.existsSync(indexHtmlPath)) {
@@ -90,9 +52,11 @@ const createApp = (
 ) => {
   const app = new Hono();
 
-  if (onDisconnect !== undefined) {
-    registerLifecycle(app, onDisconnect);
-  }
+  // SSE 端点は常時提供し、自動停止だけを onDisconnect の有無で切り替える。
+  // `--no-auto-close` でも `/api/lifecycle` を登録しないと、未登録ルートが
+  // `serveClient` の `/*` フォールバックに落ちて text/html を返し、
+  // クライアントの EventSource が error → 誤った切断バナーを出すため。
+  registerLifecycle(app, onDisconnect);
   app.route("/", createApiRouter(baseDir));
   serveClient(app, clientDir);
 

--- a/src/server/lifecycle.ts
+++ b/src/server/lifecycle.ts
@@ -1,0 +1,61 @@
+import type { Hono } from "hono";
+
+// SSE が一時的に切れても即サーバー停止しないための再接続猶予。
+// ブラウザの EventSource 既定再接続間隔 (約 3s) を十分に上回る値にする。
+export const DISCONNECT_GRACE_MS = 10000;
+
+// keep-alive 用の heartbeat 送出間隔。アイドル接続が
+// プロキシ/省電力モードで切断されるのを防ぐ。
+export const LIFECYCLE_HEARTBEAT_INTERVAL_MS = 15000;
+
+// SSE エンドポイントの提供（インフラ）と自動停止（ポリシー）を分離する。
+// `onDisconnect` 未指定（`--no-auto-close`）でも `/api/lifecycle` は常に登録し、
+// grace 経過時の副作用だけを省く。
+export const registerLifecycle = (app: Hono, onDisconnect?: () => void) => {
+  let connections = 0;
+  let graceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  app.get("/api/lifecycle", (_c) => {
+    connections += 1;
+    if (graceTimer !== null) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
+
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+    const stream = new ReadableStream({
+      cancel() {
+        if (heartbeatTimer !== null) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = null;
+        }
+        connections -= 1;
+        if (connections === 0) {
+          graceTimer = setTimeout(() => {
+            graceTimer = null;
+            if (connections === 0) {
+              onDisconnect?.();
+            }
+          }, DISCONNECT_GRACE_MS);
+        }
+      },
+      start(controller) {
+        controller.enqueue("data: connected\n\n");
+        // SSE コメント行 (":" 始まり) は EventSource にイベントとして拾われず、
+        // data ハンドラを汚さずに接続を維持できる。
+        heartbeatTimer = setInterval(() => {
+          controller.enqueue(": heartbeat\n\n");
+        }, LIFECYCLE_HEARTBEAT_INTERVAL_MS);
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "Content-Type": "text/event-stream",
+      },
+    });
+  });
+};

--- a/tests/client/components/app-error.test.tsx
+++ b/tests/client/components/app-error.test.tsx
@@ -5,6 +5,8 @@ import { fetchFile, fetchFiles } from "@/api";
 import { App } from "@/app";
 import { logError } from "@/lib/logger";
 
+import { EventSourceMock } from "../../test-utils";
+
 // API モック（per-test に挙動を差し替えるため初期実装は空）
 vi.mock(import("@/api"), () => ({
   fetchFile: vi.fn(),
@@ -21,15 +23,7 @@ vi.mock(import("@/hooks/use-theme"), () => ({
   useTheme: () => ({ theme: "light" as const, toggle: vi.fn() }),
 }));
 
-// EventSource モック（useWatch / useLifecycle で使われる）
-class EventSourceMock {
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  addEventListener() {}
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  close() {}
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  removeEventListener() {}
-}
+// EventSource モック（useWatch / useServerStatus で使われる）
 vi.stubGlobal("EventSource", EventSourceMock);
 
 // UseHotkey モック

--- a/tests/client/components/app-server-down.test.tsx
+++ b/tests/client/components/app-server-down.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { fetchFile, fetchFiles } from "@/api";
+import { App } from "@/app";
+
+import { EventSourceMock } from "../../test-utils";
+
+// API モック（per-test に挙動を差し替える）
+vi.mock(import("@/api"), () => ({
+  fetchFile: vi.fn(),
+  fetchFiles: vi.fn(),
+}));
+
+vi.mock(import("@/lib/logger"), () => ({
+  logError: vi.fn(),
+}));
+
+vi.mock(import("@/hooks/use-theme"), () => ({
+  useTheme: () => ({ theme: "light" as const, toggle: vi.fn() }),
+}));
+
+vi.mock(import("@tanstack/react-hotkeys"), () => ({
+  useHotkey: vi.fn(),
+}));
+
+// waitFor のコールバック内で条件分岐を使わずに型を絞り込むためのヘルパー。
+const requireLifecycle = (): EventSourceMock => {
+  const found = EventSourceMock.find("/api/lifecycle");
+  if (!found) {
+    throw new Error("lifecycle EventSource not created");
+  }
+  return found;
+};
+
+Object.defineProperty(window, "matchMedia", {
+  configurable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    matches: false,
+    media: query,
+    onchange: null,
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  })),
+  writable: true,
+});
+
+beforeEach(() => {
+  EventSourceMock.reset();
+  vi.stubGlobal("EventSource", EventSourceMock);
+  vi.mocked(fetchFile).mockResolvedValue("");
+  vi.mocked(fetchFiles).mockResolvedValue([]);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(App, () => {
+  it("初期表示ではサーバー停止バナーを表示しない", async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(fetchFiles).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("/api/lifecycle が error を発火するとサーバー停止バナーを表示する", async () => {
+    render(<App />);
+
+    const lifecycle = await waitFor(() => requireLifecycle());
+    act(() => {
+      lifecycle.dispatch("error");
+    });
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+  });
+
+  it("/api/lifecycle が open する（error 不発火）とバナーを表示しない", async () => {
+    // --no-auto-close でも SSE 端点は常時登録されるため、EventSource は
+    // text/event-stream を受けて open し error を発火しない。誤バナーを防ぐ回帰。
+    render(<App />);
+
+    const lifecycle = await waitFor(() => requireLifecycle());
+    act(() => {
+      lifecycle.dispatch("open");
+    });
+
+    await waitFor(() => {
+      expect(fetchFiles).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("初回ファイル取得がネットワークエラーで失敗するとサーバー停止バナーを表示する", async () => {
+    vi.mocked(fetchFiles).mockRejectedValueOnce(
+      new TypeError("Failed to fetch")
+    );
+
+    render(<App />);
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+  });
+});

--- a/tests/client/components/server-down-banner.test.tsx
+++ b/tests/client/components/server-down-banner.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { ServerDownBanner } from "@/components/server-down-banner";
+
+const originalLocation = window.location;
+let reloadMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  reloadMock = vi.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { reload: reloadMock },
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+  cleanup();
+});
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(ServerDownBanner, () => {
+  it("status=disconnected のときアラートを表示する", () => {
+    render(<ServerDownBanner status="disconnected" />);
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+
+  it("status=disconnected のときサーバー停止を伝える文言を表示する", () => {
+    render(<ServerDownBanner status="disconnected" />);
+
+    expect(screen.getByRole("alert").textContent).toMatch(/サーバー/);
+  });
+
+  it("status=disconnected のときリロードボタンのクリックで location.reload を呼ぶ", () => {
+    render(<ServerDownBanner status="disconnected" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("status=connected のときは何も表示しない", () => {
+    render(<ServerDownBanner status="connected" />);
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("status=connecting のときは何も表示しない", () => {
+    render(<ServerDownBanner status="connecting" />);
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/tests/client/hooks/use-server-status.test.ts
+++ b/tests/client/hooks/use-server-status.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+
+import { useServerStatus } from "@/hooks/use-server-status";
+
+import { EventSourceMock } from "../../test-utils";
+
+beforeEach(() => {
+  EventSourceMock.reset();
+  vi.stubGlobal("EventSource", EventSourceMock);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(useServerStatus, () => {
+  it("初期状態は connecting", () => {
+    const { result } = renderHook(() => useServerStatus());
+
+    expect(result.current).toBe("connecting");
+  });
+
+  it('mount で EventSource("/api/lifecycle") を生成する', () => {
+    renderHook(() => useServerStatus());
+
+    expect(EventSourceMock.instances).toHaveLength(1);
+    expect(EventSourceMock.last.url).toBe("/api/lifecycle");
+  });
+
+  it("open イベントで connected になる", () => {
+    const { result } = renderHook(() => useServerStatus());
+
+    act(() => {
+      EventSourceMock.last.dispatch("open");
+    });
+
+    expect(result.current).toBe("connected");
+  });
+
+  it("error イベントで disconnected になる", () => {
+    const { result } = renderHook(() => useServerStatus());
+
+    act(() => {
+      EventSourceMock.last.dispatch("error");
+    });
+
+    expect(result.current).toBe("disconnected");
+  });
+
+  it("error 後に open すると connected へ復帰する（自動再接続の表現）", () => {
+    const { result } = renderHook(() => useServerStatus());
+
+    act(() => {
+      EventSourceMock.last.dispatch("error");
+    });
+    act(() => {
+      EventSourceMock.last.dispatch("open");
+    });
+
+    expect(result.current).toBe("connected");
+  });
+
+  it("unmount で EventSource.close() が呼ばれる", () => {
+    const { unmount } = renderHook(() => useServerStatus());
+    const es = EventSourceMock.last;
+
+    unmount();
+
+    expect(es.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/client/lib/is-network-error.test.ts
+++ b/tests/client/lib/is-network-error.test.ts
@@ -1,0 +1,19 @@
+import { isNetworkError } from "@/lib/is-network-error";
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(isNetworkError, () => {
+  it('fetch のネットワーク失敗 (TypeError "Failed to fetch") を true と判定する', () => {
+    expect(isNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  it("HTTP エラー由来の Error は false と判定する", () => {
+    expect(isNetworkError(new Error("fail"))).toBe(false);
+  });
+
+  it("Error 以外の値は false と判定する", () => {
+    const undefinedValue: unknown = undefined;
+    expect(isNetworkError("string")).toBe(false);
+    expect(isNetworkError(null)).toBe(false);
+    expect(isNetworkError(undefinedValue)).toBe(false);
+  });
+});

--- a/tests/server/cli-lifecycle.test.ts
+++ b/tests/server/cli-lifecycle.test.ts
@@ -1,0 +1,191 @@
+import {
+  DISCONNECT_GRACE_MS,
+  LIFECYCLE_HEARTBEAT_INTERVAL_MS,
+  registerLifecycle,
+} from "@server/lifecycle";
+import { Hono } from "hono";
+
+// SSE チャンクは実装が string / Uint8Array どちらでも enqueue しうるため、
+// 取得経路をエンコードに依存させない。
+const decodeChunk = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value instanceof Uint8Array) {
+    return new TextDecoder().decode(value);
+  }
+  throw new Error("unexpected SSE chunk type");
+};
+
+const setupLifecycle = () => {
+  const onDisconnect = vi.fn();
+  const app = new Hono();
+  registerLifecycle(app, onDisconnect);
+  return { app, onDisconnect };
+};
+
+const openLifecycle = async (
+  app: Hono
+): Promise<ReadableStreamDefaultReader<unknown>> => {
+  const res = await app.request("/api/lifecycle");
+  if (!res.body) {
+    throw new Error("res.body is null");
+  }
+  return res.body.getReader();
+};
+
+// eslint-disable-next-line eslint-plugin-jest/valid-title -- prefer-describe-function-title requires function reference
+describe(registerLifecycle, () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("接続確立", () => {
+    it("text/event-stream ヘッダを返す", async () => {
+      const { app } = setupLifecycle();
+
+      const res = await app.request("/api/lifecycle");
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+    });
+
+    it("接続直後に connected を送出する", async () => {
+      const { app } = setupLifecycle();
+      const reader = await openLifecycle(app);
+
+      const { value } = await reader.read();
+
+      expect(decodeChunk(value)).toContain("connected");
+      await reader.cancel();
+    });
+  });
+
+  describe("heartbeat (keep-alive)", () => {
+    it("heartbeat 間隔の経過ごとに SSE コメント行を送出する", async () => {
+      const { app } = setupLifecycle();
+      const reader = await openLifecycle(app);
+      // connected を読み捨てる
+      await reader.read();
+
+      const heartbeatRead = reader.read();
+      await vi.advanceTimersByTimeAsync(LIFECYCLE_HEARTBEAT_INTERVAL_MS);
+      const { value } = await heartbeatRead;
+
+      // コメント行 (":" 始まり) は EventSource にイベントとして拾われず、
+      // 既存の data ハンドラを汚さない（plan の設計意図）。
+      expect(decodeChunk(value).startsWith(":")).toBe(true);
+      await reader.cancel();
+    });
+
+    it("heartbeat 間隔未満の経過では追加送出しない", async () => {
+      const { app } = setupLifecycle();
+      const reader = await openLifecycle(app);
+      // connected
+      await reader.read();
+
+      const pendingRead = reader.read();
+      await vi.advanceTimersByTimeAsync(LIFECYCLE_HEARTBEAT_INTERVAL_MS - 1);
+      const race = await Promise.race([
+        pendingRead.then(() => "got" as const),
+        Promise.resolve("pending" as const),
+      ]);
+
+      expect(race).toBe("pending");
+      await reader.cancel();
+    });
+  });
+
+  describe("切断 grace と再接続", () => {
+    it("切断後 grace 未満では onDisconnect を呼ばない", async () => {
+      const { app, onDisconnect } = setupLifecycle();
+      const reader = await openLifecycle(app);
+      // connected
+      await reader.read();
+
+      await reader.cancel();
+      await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS - 1);
+
+      expect(onDisconnect).not.toHaveBeenCalled();
+    });
+
+    it("切断後 grace 経過で onDisconnect を 1 回呼ぶ", async () => {
+      const { app, onDisconnect } = setupLifecycle();
+      const reader = await openLifecycle(app);
+      // connected
+      await reader.read();
+
+      await reader.cancel();
+      await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
+
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("grace 期間内に再接続すると onDisconnect は呼ばれない", async () => {
+      const { app, onDisconnect } = setupLifecycle();
+      const reader1 = await openLifecycle(app);
+      // connected
+      await reader1.read();
+
+      // 一時切断 → grace 開始
+      await reader1.cancel();
+      await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS - 1);
+      // grace 内に再接続
+      const reader2 = await openLifecycle(app);
+      // connected
+      await reader2.read();
+      await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
+
+      expect(onDisconnect).not.toHaveBeenCalled();
+      await reader2.cancel();
+    });
+  });
+
+  describe("onDisconnect 未指定 (--no-auto-close 相当)", () => {
+    it("onDisconnect なしでも /api/lifecycle は text/event-stream を返す", async () => {
+      const app = new Hono();
+      registerLifecycle(app);
+
+      const res = await app.request("/api/lifecycle");
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+    });
+
+    it("onDisconnect なしで切断 → grace 経過しても副作用なく例外も投げない", async () => {
+      const app = new Hono();
+      registerLifecycle(app);
+      const reader = await openLifecycle(app);
+      // connected
+      await reader.read();
+
+      await reader.cancel();
+      await expect(
+        vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS)
+      ).resolves.not.toThrow();
+      // grace タイマー発火後に残存タイマーが 0 なら interval も解放済み。
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+
+  describe("リソース解放", () => {
+    it("切断 → grace 経過後にタイマーが残らない（heartbeat リークしない）", async () => {
+      const { app, onDisconnect } = setupLifecycle();
+      const reader = await openLifecycle(app);
+      // connected
+      await reader.read();
+
+      await reader.cancel();
+      await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
+
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+      // grace タイマー発火後に残存タイマーが 0 なら heartbeat interval は解放済み。
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+});

--- a/tests/test-utils-event-source-mock.test.ts
+++ b/tests/test-utils-event-source-mock.test.ts
@@ -6,6 +6,10 @@ import { EventSourceMock, installEventSourceMock } from "./test-utils";
 // helper の契約をここで固定する。過去の architect-review
 // (ARCH-NEW-tests-event-source-mock-dup) を参照。
 describe("EventSourceMock", () => {
+  beforeEach(() => {
+    EventSourceMock.reset();
+  });
+
   it("EventSource interface を実装している", () => {
     const es = new EventSourceMock("/api/watch");
 
@@ -21,6 +25,35 @@ describe("EventSourceMock", () => {
     const es = new EventSourceMock(new URL("http://localhost/api/watch"));
 
     expect(es.url).toBe("http://localhost/api/watch");
+  });
+
+  it("生成 instance を static instances / last / find で追跡できる", () => {
+    const a = new EventSourceMock("/api/watch");
+    const b = new EventSourceMock("/api/lifecycle");
+
+    expect(EventSourceMock.instances).toHaveLength(2);
+    expect(EventSourceMock.last).toBe(b);
+    expect(EventSourceMock.find("/api/watch")).toBe(a);
+    expect(EventSourceMock.find("/api/missing")).toBeUndefined();
+  });
+
+  it("dispatch は addEventListener 登録リスナーを発火する", () => {
+    const es = new EventSourceMock("/api/lifecycle");
+    const onOpen = vi.fn();
+    es.addEventListener("open", onOpen);
+
+    es.dispatch("open");
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("reset で instances を空にする", () => {
+    const es = new EventSourceMock("/api/watch");
+    expect(EventSourceMock.instances).toContain(es);
+
+    EventSourceMock.reset();
+
+    expect(EventSourceMock.instances).toHaveLength(0);
   });
 });
 

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -54,14 +54,19 @@ export function expectApiErrorResponse(
   expect(isApiErrorResponse(value)).toBe(true);
 }
 
-// jsdom 環境向けの no-op `EventSource` 実装。
-// `useWatch` が `new EventSource(...)` する経路でレンダリングが落ちないようにするためだけのもので、
-// 実際の SSE 動作はテストしない。SSE 振る舞いをテストする側は `tests/client/hooks/use-watch.test.ts` の
-// `MockEventSource`（dispatch/dispatchRaw 付き）を使う。
+// jsdom 環境向けの `EventSource` モック。
+// `useWatch` / `useServerStatus` が `new EventSource(...)` する経路を支える。
+// 生成された instance を `static instances` で追跡し、`dispatch(type)` で
+// `addEventListener` 登録済みリスナーを発火できる（open/error 等の検証用）。
+// production (`src/client/hooks/use-server-status.ts`) は `addEventListener`
+// 経路のみ使うため、`onopen`/`onerror` field 経由の発火はサポートしない。
+// payload 付き event を扱う variant は `tests/client/hooks/use-watch.test.ts`
+// の `MockEventSource`（dispatch/dispatchRaw 付き）を使う。
 export class EventSourceMock implements EventSource {
   static readonly CONNECTING = 0;
   static readonly OPEN = 1;
   static readonly CLOSED = 2;
+  static instances: EventSourceMock[] = [];
   readonly CONNECTING = 0;
   readonly OPEN = 1;
   readonly CLOSED = 2;
@@ -71,20 +76,69 @@ export class EventSourceMock implements EventSource {
   onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
   onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
   onopen: ((this: EventSource, ev: Event) => unknown) | null = null;
+  close = vi.fn();
+  private readonly listeners = new Map<
+    string,
+    EventListenerOrEventListenerObject[]
+  >();
 
   constructor(url: string | URL, _eventSourceInitDict?: EventSourceInit) {
     this.url = typeof url === "string" ? url : url.toString();
+    EventSourceMock.instances.push(this);
+  }
+
+  addEventListener<K extends keyof EventSourceEventMap>(
+    type: K,
+    listener: (this: EventSource, ev: EventSourceEventMap[K]) => unknown,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject
+  ): void {
+    const arr = this.listeners.get(type) ?? [];
+    arr.push(listener);
+    this.listeners.set(type, arr);
   }
 
   // eslint-disable-next-line class-methods-use-this, no-empty-function
-  addEventListener() {}
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
-  close() {}
-  // eslint-disable-next-line class-methods-use-this, no-empty-function
   removeEventListener() {}
+
   // eslint-disable-next-line class-methods-use-this
   dispatchEvent(_event: Event): boolean {
     return false;
+  }
+
+  dispatch(type: string) {
+    const event = new Event(type);
+    for (const listener of this.listeners.get(type) ?? []) {
+      if (typeof listener === "function") {
+        listener(event);
+      } else {
+        listener.handleEvent(event);
+      }
+    }
+  }
+
+  static get last(): EventSourceMock {
+    const inst = EventSourceMock.instances.at(-1);
+    if (!inst) {
+      throw new Error("EventSourceMock has not been instantiated");
+    }
+    return inst;
+  }
+
+  static find(url: string): EventSourceMock | undefined {
+    return EventSourceMock.instances.find((i) => i.url === url);
+  }
+
+  static reset() {
+    EventSourceMock.instances = [];
   }
 }
 


### PR DESCRIPTION
## Summary

## 概要

specv を起動したまま長時間放置するとサーバープロセスが切断されてしまい、ブラウザをリロードしても復帰できない。サーバーを再起動するまで利用不能になる。

## 背景・目的

specv は `/api/lifecycle` の SSE 接続でブラウザ切断を検知してサーバーを自動停止する設計（CLAUDE.md 記載）。この機構が「実際にはブラウザは開いたままだが SSE が切れた状態」を「ブラウザを閉じた」と誤判定し、サーバーが意図せず終了している可能性が高い。長時間ローカルプレビューを開きっぱなしにする利用形態が壊れている。

## 再現手順

1. `nr dev` で client / server を起動する
2. ブラウザでプレビュー画面を開く
3. そのまま長時間放置する（具体的な閾値は plan step で確定する）
4. ブラウザに戻ってリロードまたは操作する

## 期待される動作

- 長時間経過してもサーバーが意図せず停止しない
- 仮にネットワーク的に SSE が一時切断されても、ブラウザがフォアグラウンドにある限りサーバーは生存し続ける
- 万一サーバーが終了した場合、ブラウザリロードで「サーバーが停止している」旨を明示する（無言で白画面/操作不能にしない）

## 実際の動作

- 長時間放置後にサーバープロセスが終了している
- ブラウザリロードでも復帰せず、API が全て失敗する
- 再度 `nr dev` で起動し直す必要がある

## 影響範囲

- 開発者が specv を常時起動しておく利用形態（ドキュメントを開きっぱなしで適宜参照する）が破綻する
- 切断要因が SSE 起因なら、ネットワーク不安定なテザリング/省電力モードでも頻発する可能性

## 参照資料

- src/server/cli.ts
- src/server/api.ts
- src/client/hooks/
- src/client/lib/watch-handler.ts
- (plan step で確定する: SSE keep-alive / heartbeat の実装箇所、ブラウザ側 EventSource の再接続ハンドリング)

## 影響ファイル

- **変更**: src/server/api.ts （`/api/lifecycle` の切断検知ロジック・heartbeat）
- **変更**: src/server/cli.ts （サーバー終了条件の見直し）
- **変更**: src/client 配下の SSE 接続ハンドラ（再接続/復帰処理）
- (plan step で確定する: 上記の正確なファイル特定と新規ファイル要否)

## 要件

1. 長時間（最低でも数時間レンジ）ブラウザを開いたまま放置してもサーバーが意図せず終了しないこと
2. SSE 接続が一時的に切れた場合でも即座にサーバー停止判定をせず、再接続猶予期間を設けること（具体的な猶予時間は plan step で確定する）
3. クライアント側で SSE が切れた場合、自動で再接続を試みること
4. サーバーが終了した状態でブラウザリロードした場合、API エラーを握り潰さず「サーバー停止」状態を UI で明示すること
5. 上記挙動を検証する Unit/E2E テストを追加すること（SSE のフェイク or タイマー操作で検証）

## スコープ外

- 「ブラウザを閉じたら自動停止」仕様自体の変更は行わない（意図的設計のため維持）
- PWA 化やオフライン対応など、サーバー無しでの動作実現は対象外
- 複数タブ同時オープン時のライフサイクル整合性（→ 必要なら別 issue 化）

## 受け入れ基準

- [ ] 数時間レベルのアイドル後でもサーバーが生存していることをローカルで確認
- [ ] SSE 切断をエミュレートしてもサーバーが即終了しないことをテストで保証
- [ ] サーバー停止時のリロードで明示的なエラー画面が出ることをテストで保証

## 実装方針（takt）

- workflow: default
- 理由: SSE ライフサイクルというロジック変更を伴い、server / client 双方の複数ファイルに渡る可能性が高い。テスト先行で再現と修正の境界を固めたいため default に寄せる（fail-safe）

## Execution Report

Workflow `default` completed successfully.

Closes #141