### PR TITLE
[#142] issue-142-insutansu-ni-no-de-k

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ npx specv@latest -p 3000
 
 A browser window opens automatically, rendering your Markdown files with GitHub-style formatting.
 
+### Multiple instances
+
+Running `specv` in more than one directory at the same time is supported. Each
+instance is independent: if the requested port is already in use, specv falls
+back to the next free port instead of taking over the existing one. The actual
+URL is printed in the `➜  Local:` line and the matching browser tab is opened,
+so each window keeps showing its own directory.
+
 ## Keyboard Shortcuts
 
 | Shortcut           | Action              |

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 import fs from "node:fs";
-import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { isObjectRecord } from "@shared/is-object-record";
 import { program } from "commander";
@@ -12,9 +10,7 @@ import { Hono } from "hono";
 
 import { createApiRouter } from "./api";
 import { registerLifecycle } from "./lifecycle";
-import { getLocalIpAddress } from "./network";
-import { openInBrowser } from "./open-browser";
-import { displayQrCode } from "./qr-display";
+import { announceAndOpen, listenWithFallback } from "./listen";
 
 const packageJsonPath = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -81,7 +77,7 @@ program
   .option("-p, --port <number>", "Port number", "4649")
   .option("--host", "Expose to local network (enables QR code)")
   .option("--no-auto-close", "Disable auto-close on client disconnect")
-  .action((options: CliOptions) => {
+  .action(async (options: CliOptions) => {
     const baseDir = process.cwd();
     const startPort = Number.parseInt(options.port, 10);
     const clientDir = path.join(currentDir, "../client");
@@ -97,65 +93,23 @@ program
         : undefined
     );
 
-    const announceAndOpen = async (info: AddressInfo): Promise<void> => {
-      const localUrl = `http://localhost:${info.port}`;
-      console.log("");
-      console.log(`  specv v${program.version()}`);
-      console.log("");
-      console.log(`  ➜  Local:   ${localUrl}`);
-
-      const ip = networkConfig.enableNetwork ? getLocalIpAddress() : null;
-      const networkUrl = ip === null ? null : `http://${ip}:${info.port}`;
-
-      if (networkUrl !== null) {
-        console.log(`  ➜  Network: ${networkUrl}`);
-      } else if (!networkConfig.enableNetwork) {
-        console.log("  ➜  Network: use --host to expose to local network");
-      }
-
-      console.log("");
-      console.log(`  Serving: ${baseDir}`);
-
-      // Dev:host 時は Vite プラグイン側で QR を表示するためスキップ。
-      // SPECV_HOST="" は未設定と同義として扱う（`vite.config.ts:93` の Boolean(process.env.SPECV_HOST) と整合）
-      if (
-        networkUrl !== null &&
-        (process.env.SPECV_HOST === undefined || process.env.SPECV_HOST === "")
-      ) {
-        console.log("");
-        displayQrCode(networkUrl);
-      }
-
-      console.log("");
-      console.log("  Press Ctrl+C to stop");
-
-      try {
-        await openInBrowser(localUrl);
-      } catch {
-        console.log(`  Open ${localUrl} in your browser`);
-      }
-    };
-
-    const tryListen = (port: number): void => {
-      const server = serve(
-        { fetch: app.fetch, hostname: networkConfig.hostname, port },
-        (info) => {
-          void announceAndOpen(info);
-        }
+    try {
+      const { port } = await listenWithFallback(
+        app,
+        networkConfig.hostname,
+        startPort
       );
-
-      server.on("error", (err: NodeJS.ErrnoException) => {
-        if (err.code === "EADDRINUSE" && port < startPort + 10) {
-          console.log(`Port ${port} is in use, trying ${port + 1}...`);
-          tryListen(port + 1);
-        } else {
-          console.error(`Failed to start server: ${err.message}`);
-          process.exit(1);
-        }
+      await announceAndOpen({
+        port,
+        baseDir,
+        enableNetwork: networkConfig.enableNetwork,
+        version: pkg.version,
       });
-    };
-
-    tryListen(startPort);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Failed to start server: ${message}`);
+      process.exit(1);
+    }
   });
 
 program.parse();

--- a/src/server/listen.ts
+++ b/src/server/listen.ts
@@ -1,0 +1,98 @@
+import type { AddressInfo } from "node:net";
+
+import { serve, type ServerType } from "@hono/node-server";
+import type { Hono } from "hono";
+
+import { getLocalIpAddress } from "./network";
+import { openInBrowser } from "./open-browser";
+import { displayQrCode } from "./qr-display";
+
+interface ListenResult {
+  port: number;
+  server: ServerType;
+}
+
+// ポリシー: 複数インスタンス起動を許容する。別ディレクトリで specv を同時起動
+// した場合、2 番目以降は startPort が EADDRINUSE のたびに次ポートへフォールバック
+// して独立に bind する。これにより「後勝ち」でポートを奪い合うことがなく、各画面
+// は自身のディレクトリ内容を表示し続ける（Issue #142）。
+export const listenWithFallback = (
+  app: Hono,
+  hostname: string,
+  startPort: number,
+  maxRetries = 10
+): Promise<ListenResult> =>
+  new Promise<ListenResult>((resolve, reject) => {
+    const attempt = (port: number, retriesLeft: number): void => {
+      const server = serve(
+        { fetch: app.fetch, hostname, port },
+        (info: AddressInfo) => {
+          resolve({ port: info.port, server });
+        }
+      );
+
+      server.on("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EADDRINUSE" && retriesLeft > 0) {
+          console.log(`Port ${port} is in use, trying ${port + 1}...`);
+          attempt(port + 1, retriesLeft - 1);
+        } else {
+          reject(err);
+        }
+      });
+    };
+
+    attempt(startPort, maxRetries);
+  });
+
+interface AnnounceParams {
+  port: number;
+  baseDir: string;
+  enableNetwork: boolean;
+  version: string;
+}
+
+// 実際に bind した port を起動バナー・ブラウザ open URL に反映する。
+// 固定ポートを決め打ちしないことが Issue #142 要件4 の核心。
+export const announceAndOpen = async ({
+  port,
+  baseDir,
+  enableNetwork,
+  version,
+}: AnnounceParams): Promise<void> => {
+  const localUrl = `http://localhost:${port}`;
+  console.log("");
+  console.log(`  specv v${version}`);
+  console.log("");
+  console.log(`  ➜  Local:   ${localUrl}`);
+
+  const ip = enableNetwork ? getLocalIpAddress() : null;
+  const networkUrl = ip === null ? null : `http://${ip}:${port}`;
+
+  if (networkUrl !== null) {
+    console.log(`  ➜  Network: ${networkUrl}`);
+  } else if (!enableNetwork) {
+    console.log("  ➜  Network: use --host to expose to local network");
+  }
+
+  console.log("");
+  console.log(`  Serving: ${baseDir}`);
+
+  // Dev:host 時は Vite プラグイン側で QR を表示するためスキップ。
+  // SPECV_HOST="" は未設定と同義として扱う（vite.config.ts の Boolean(process.env.SPECV_HOST) と整合）
+  if (
+    networkUrl !== null &&
+    (process.env.SPECV_HOST === undefined || process.env.SPECV_HOST === "")
+  ) {
+    console.log("");
+    displayQrCode(networkUrl);
+  }
+
+  console.log("");
+  console.log("  Press Ctrl+C to stop");
+
+  try {
+    await openInBrowser(localUrl);
+  } catch {
+    console.log(`  Open ${localUrl} in your browser`);
+  }
+};

--- a/tests/server/announce.test.ts
+++ b/tests/server/announce.test.ts
@@ -1,0 +1,85 @@
+import { announceAndOpen } from "@server/listen";
+import { getLocalIpAddress } from "@server/network";
+import { openInBrowser } from "@server/open-browser";
+import { displayQrCode } from "@server/qr-display";
+
+// Issue #142 要件4: CLI 出力とブラウザ起動 URL は固定文言ではなく
+// 実際に bind した port を反映しなければならない。
+// announceAndOpen を cli.ts の program.action クロージャから副作用のない
+// モジュール (@server/listen) へ切り出し、依存を引数で受ける純関数として検証する。
+// (`@server/cli` を import すると program.parse() が走り実サーバ起動とブラウザ
+//  起動の副作用が発生するため、テスト対象を cli.ts に置くことはできない)
+
+vi.mock("@server/open-browser");
+vi.mock("@server/network");
+vi.mock("@server/qr-display");
+
+const baseParams = {
+  baseDir: "/tmp/proj",
+  enableNetwork: false,
+  version: "9.9.9",
+};
+
+describe("announceAndOpen", () => {
+  beforeEach(() => {
+    vi.mocked(openInBrowser).mockResolvedValue();
+    vi.mocked(getLocalIpAddress).mockReturnValue(null);
+    vi.mocked(displayQrCode).mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("port を反映した URL でブラウザを開く", async () => {
+    await announceAndOpen({ ...baseParams, port: 5173 });
+
+    expect(openInBrowser).toHaveBeenCalledWith("http://localhost:5173");
+  });
+
+  it("Local 行に固定ポートではなく実際の bind port を表示する", async () => {
+    await announceAndOpen({ ...baseParams, port: 5173 });
+
+    expect(console.log).toHaveBeenCalledWith(
+      "  ➜  Local:   http://localhost:5173"
+    );
+  });
+
+  it("version 引数を起動バナーに表示する", async () => {
+    await announceAndOpen({ ...baseParams, port: 5173 });
+
+    expect(console.log).toHaveBeenCalledWith("  specv v9.9.9");
+  });
+
+  it("baseDir 引数を Serving 行に表示する", async () => {
+    await announceAndOpen({ ...baseParams, port: 5173 });
+
+    expect(console.log).toHaveBeenCalledWith("  Serving: /tmp/proj");
+  });
+
+  it("ブラウザ起動に失敗した場合は手動で開く URL を案内する", async () => {
+    vi.mocked(openInBrowser).mockRejectedValue(new Error("no browser"));
+
+    await announceAndOpen({ ...baseParams, port: 5173 });
+
+    expect(console.log).toHaveBeenCalledWith(
+      "  Open http://localhost:5173 in your browser"
+    );
+  });
+
+  it("--host 有効時は Network 行に port を反映した URL を表示する", async () => {
+    vi.mocked(getLocalIpAddress).mockReturnValue("192.168.1.10");
+
+    await announceAndOpen({
+      baseDir: "/tmp/proj",
+      enableNetwork: true,
+      version: "9.9.9",
+      port: 5173,
+    });
+
+    expect(console.log).toHaveBeenCalledWith(
+      "  ➜  Network: http://192.168.1.10:5173"
+    );
+  });
+});

--- a/tests/server/listen.test.ts
+++ b/tests/server/listen.test.ts
@@ -1,0 +1,181 @@
+import net from "node:net";
+
+import { listenWithFallback } from "@server/listen";
+import { Hono } from "hono";
+
+// Issue #142: 別ディレクトリで specv を複数起動したとき、各インスタンスが
+// 別ポートに独立して bind され「後勝ち」で上書きされないことを保証する。
+// 実 TCP を占有して "別プロセスが既にポートを握っている" 状況を再現する。
+
+const HOST = "127.0.0.1";
+
+const createApp = (): Hono => {
+  const app = new Hono();
+  app.get("/", (c) => c.text("ok"));
+  return app;
+};
+
+const getFreePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.once("error", reject);
+    probe.listen(0, HOST, () => {
+      const addr = probe.address();
+      if (addr === null || typeof addr === "string") {
+        probe.close();
+        reject(new Error("could not determine a free port"));
+        return;
+      }
+      const { port } = addr;
+      probe.close(() => {
+        resolve(port);
+      });
+    });
+  });
+
+const canBind = (port: number): Promise<boolean> =>
+  new Promise((resolve) => {
+    const probe = net.createServer();
+    probe.once("error", () => {
+      resolve(false);
+    });
+    probe.listen(port, HOST, () => {
+      probe.close(() => {
+        resolve(true);
+      });
+    });
+  });
+
+// startPort と startPort+1 が同時に空いている基準ポートを探す。
+// フォールバック先 (startPort+1) を決め打ちで検証するために必要。
+const getConsecutiveFreePort = async (): Promise<number> => {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const base = await getFreePort();
+    if ((await canBind(base)) && (await canBind(base + 1))) {
+      return base;
+    }
+  }
+  throw new Error("could not find two consecutive free ports");
+};
+
+const occupiers: net.Server[] = [];
+const started: Array<{ close: (callback?: () => void) => void }> = [];
+
+const occupy = (port: number): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(port, HOST, () => {
+      occupiers.push(srv);
+      resolve();
+    });
+  });
+
+const closeAll = (
+  servers: Array<{ close: (callback?: () => void) => void }>
+): Promise<void[]> =>
+  Promise.all(
+    servers.map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => {
+            resolve();
+          });
+        })
+    )
+  );
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+describe("listenWithFallback", () => {
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    await closeAll(started);
+    await closeAll(occupiers);
+    started.length = 0;
+    occupiers.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("空きポートで listen でき、実際に bind した port を resolve する", async () => {
+    const port = await getFreePort();
+
+    const result = await listenWithFallback(createApp(), HOST, port);
+    started.push(result.server);
+
+    expect(result.port).toBe(port);
+  });
+
+  it("startPort が使用中なら startPort+1 にフォールバックして bind する", async () => {
+    const base = await getConsecutiveFreePort();
+    await occupy(base);
+
+    const result = await listenWithFallback(createApp(), HOST, base);
+    started.push(result.server);
+
+    expect(result.port).toBe(base + 1);
+  });
+
+  it("同一 startPort から 2 回起動すると 2 つ目は別ポートに bind され互いに干渉しない", async () => {
+    const base = await getConsecutiveFreePort();
+
+    const first = await listenWithFallback(createApp(), HOST, base);
+    started.push(first.server);
+    const second = await listenWithFallback(createApp(), HOST, base);
+    started.push(second.server);
+
+    expect(first.port).toBe(base);
+    expect(second.port).toBe(base + 1);
+    expect(second.port).not.toBe(first.port);
+  });
+
+  it("フォールバック時に使用中ポートと次ポートを示すメッセージをログ出力する", async () => {
+    const base = await getConsecutiveFreePort();
+    await occupy(base);
+
+    const result = await listenWithFallback(createApp(), HOST, base);
+    started.push(result.server);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      `Port ${base} is in use, trying ${base + 1}...`
+    );
+  });
+
+  it("リトライ枠が無い (maxRetries=0) 状態で startPort が使用中なら reject する", async () => {
+    const port = await getFreePort();
+    await occupy(port);
+
+    await expect(
+      listenWithFallback(createApp(), HOST, port, 0)
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("startPort から maxRetries 先まで全て使用中なら reject する", async () => {
+    const base = await getConsecutiveFreePort();
+    await occupy(base);
+    await occupy(base + 1);
+
+    await expect(
+      listenWithFallback(createApp(), HOST, base, 1)
+    ).rejects.toBeInstanceOf(Error);
+    // base が使用中なので 1 回はフォールバックを試みている
+    expect(logSpy).toHaveBeenCalledWith(
+      `Port ${base} is in use, trying ${base + 1}...`
+    );
+  });
+
+  it("EADDRINUSE 以外のエラーではフォールバックせず即 reject する", async () => {
+    const port = await getFreePort();
+
+    // RFC5737 TEST-NET-1 (192.0.2.0/24) は割り当て不能で EADDRNOTAVAIL になる
+    await expect(
+      listenWithFallback(createApp(), "192.0.2.1", port)
+    ).rejects.toBeInstanceOf(Error);
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("is in use")
+    );
+  });
+});


### PR DESCRIPTION
## Summary

## 概要

別ディレクトリで specv を複数同時起動すると、先に開いていた画面に「最後に起動したインスタンス」のディレクトリ内容が表示されてしまい、本来見たいディレクトリの内容にアクセスできなくなる。複数プロジェクト並行作業時に体験が破綻する。

## 背景・目的

specv は CLI で `nlx specv` 起動時に固定ポートで Hono サーバーと Vite dev server を立ち上げる構成。複数インスタンス起動時にポート衝突 or 後勝ちで bind しているか、別ポートで起動していても画面側が同一 origin を参照しているかのいずれかで、ユーザーから見ると「先に開いた画面が後発の内容で塗り潰される」状況になる。本来は各ディレクトリが独立して観測可能であるべき（または明示的に複数起動を拒否すべき）。

## 再現手順

1. ディレクトリ A で `nlx specv`（あるいは `nr dev`）を起動する
2. ブラウザで A のプレビューを開く
3. 別ターミナルでディレクトリ B に移動し、もう一度 `nlx specv` を起動する
4. ディレクトリ A の画面をリロード、または別タブで開き直す

## 期待される動作

- 各インスタンスは互いに干渉せず、A の画面では A のディレクトリの内容が表示され続ける
- もしくは、複数起動を許容しない設計なら、2 回目の起動時点で「既に specv が起動しています（ポート XXXX 使用中）」と明示エラーで終了する
- 複数起動を許容する場合、各インスタンスのアクセス URL を CLI 出力に明示する

## 実際の動作

- 後発の起動が走った時点で、先に開いていた画面が後発側のディレクトリ内容を表示するようになる
- 結果として、最後に起動したディレクトリ以外は参照不能になる

## 影響範囲

- 複数プロジェクトを並行作業する利用形態（specv の主要ユースケースの一つ）が破綻する
- ポート bind が後勝ちになっているなら、CLI からのエラー検知も効かず silent な不具合になる

## 参照資料

- src/server/cli.ts
- src/server/api.ts
- README.md
- (plan step で確定する: ポート bind 実装箇所、Vite dev server のポート決定、CLI ブラウザ自動 open ロジック)

## 影響ファイル

- **変更**: src/server/cli.ts （ポート決定・ブラウザ open・複数起動時のハンドリング）
- (plan step で確定する: Vite 設定ファイル、client 側のサーバー URL 取得箇所、CLI 出力周り)

## 要件

1. 既に specv が起動している状態で再度 `nlx specv` を実行した場合の挙動を明確に定義する（複数起動許容 / 拒否 のどちらかにポリシー決定する）
2. ポリシーが「複数起動許容」の場合: 各インスタンスが別ポートで起動し、互いに干渉せず独立して動作すること。ブラウザは起動したインスタンス自身の URL を開く
3. ポリシーが「複数起動拒否」の場合: 2 回目の起動コマンドが「既に起動中」を明示してエラー終了する。既存の起動インスタンスは影響を受けない
4. CLI 出力で実際に bind したポートとアクセス URL を明示する（固定文言の決め打ちにしない）
5. 上記挙動を検証する Unit/E2E テストを追加する（複数プロセス起動シナリオの再現可能なテスト）

## スコープ外

- 単一 specv プロセスで複数ディレクトリを同時にプレビューするマルチワークスペース機能（→ 別 issue 化）
- インスタンス間の状態同期（テーマ・展開状態など）
- グローバルなディスカバリ/レジストリ的な仕組み

## 受け入れ基準

- [ ] ディレクトリ A / B で並行起動しても、A 側の画面に B の内容が混入しない
- [ ] 採用したポリシーに沿った挙動（独立起動 or 明示エラー）がテストで保証されている
- [ ] CLI 出力に正しいポート / URL が表示される

## 実装方針（takt）

- workflow: default
- 理由: 起動ポリシーの設計判断（複数起動許容 / 拒否）を伴い、CLI ・サーバー・場合により client URL 解決の複数ファイルに渡る。テスト先行で挙動境界を固めたいため default に寄せる（fail-safe）

## Execution Report

Workflow `default` completed successfully.

Closes #142